### PR TITLE
Solution for the issue #246, Multiple connection and BLE notification callback in android on re-connection 

### DIFF
--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -88,8 +88,17 @@ namespace Plugin.BLE.Android
             }
             else
             {
-                /*_gatt = */
-                BluetoothDevice.ConnectGatt(Application.Context, connectParameters.AutoConnect, _gattCallback);
+                // If gatt is null then initiate the connection process by passing application context , connection parameters
+                //and gattcallbacks.
+                if (null == _gatt)
+                {
+                    _gatt = BluetoothDevice.ConnectGatt(Application.Context, connectParameters.AutoConnect, _gattCallback);
+                }
+                //else a valid gatt object is already exist.Just call connect. DO NOT craete new Gatt object by calling ConnectGatt.
+                else
+                {
+                    _gatt.Connect();
+                }
             }
         }
 

--- a/Source/Plugin.BLE.Android/GattCallback.cs
+++ b/Source/Plugin.BLE.Android/GattCallback.cs
@@ -77,7 +77,10 @@ namespace Plugin.BLE.Android
                         }
                         else
                         {
-                            //we already hadled device error so no need th raise disconnect event(happens when device not in range)
+                            //Disconnection is requested by the application . So set the gatt object to null.
+                            //close the gatt client object.
+                            _device.Update(gatt.Device, null);
+                            gatt.Close();
                             _adapter.HandleDisconnectedDevice(true, _device);
                         }
                         break;


### PR DESCRIPTION
#246
@xabre 

"BluetoothDevice.ConnectGatt" should be only called once for a particular BluetoothDevice. For subsequent re-connections "Gatt.Connect" should be called. Otherwise duplicate Gatt objects will be created. This would lead to inconsistencies and memory leaks.

In case of Auto re connection set to true, If the BLE device was disconnected (from the Application Manually - on Firing Disconnect), Gatt object was not closed properly. Added logic to close the Gatt object for above mentioned scenario. 