### PR TITLE
Fix problems with MAUI on Windows

### DIFF
--- a/Source/BLE.Client/BLE.Client.UWP/BLE.Client.UWP.csproj
+++ b/Source/BLE.Client/BLE.Client.UWP/BLE.Client.UWP.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -175,7 +175,7 @@
       <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.13</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross">
       <Version>8.0.2</Version>

--- a/Source/Plugin.BLE/Plugin.BLE.csproj
+++ b/Source/Plugin.BLE/Plugin.BLE.csproj
@@ -43,6 +43,7 @@
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-android'))">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.17763.0</TargetPlatformMinVersion>
+		<TargetPlatformMinVersion Condition=" $(TargetFramework.StartsWith('uap10.0')) ">10.0.17763.0</TargetPlatformMinVersion>
 	</PropertyGroup>
 
 	  <PropertyGroup Condition=" '$(Configuration)'=='Release' And '$(OS)' == 'Windows_NT' ">
@@ -77,17 +78,13 @@
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
 		<Compile Include="**\Windows\**\*.cs" />
-		<PackageReference Include="Microsoft.Toolkit.Uwp.Connectivity" Version="6.1.1" />
+		<PackageReference Include="Microsoft.Toolkit.Uwp.Connectivity" Version="7.1.3" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.Contains('-windows')) ">
 		<Compile Include="**\Windows\**\*.cs" />
 		<PackageReference Include="CommunityToolkit.WinUI.Connectivity" Version="7.1.2" />
 	</ItemGroup>
-
-	<PropertyGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
-		<TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-	</PropertyGroup>
 
 	<PropertyGroup Condition=" $(TargetFramework.Contains('-android')) ">
 	</PropertyGroup>

--- a/Source/Plugin.BLE/Windows/Device.cs
+++ b/Source/Plugin.BLE/Windows/Device.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Threading.Tasks;
 
 #if WINDOWS_UWP
+using Windows.System;
 using Microsoft.Toolkit.Uwp.Connectivity;
 #else
+using Microsoft.UI.Dispatching;
 using CommunityToolkit.WinUI.Connectivity;
 #endif
 using Windows.Devices.Bluetooth;
@@ -17,8 +19,8 @@ namespace Plugin.BLE.UWP
 {
     public class Device : DeviceBase<ObservableBluetoothLEDevice>
     {
-        public Device(Adapter adapter, BluetoothLEDevice nativeDevice, int rssi, Guid id, IReadOnlyList<AdvertisementRecord> advertisementRecords = null) 
-            : base(adapter, new ObservableBluetoothLEDevice(nativeDevice.DeviceInformation)) 
+        public Device(Adapter adapter, BluetoothLEDevice nativeDevice, int rssi, Guid id, DispatcherQueue dq, IReadOnlyList<AdvertisementRecord> advertisementRecords = null) 
+            : base(adapter, new ObservableBluetoothLEDevice(nativeDevice.DeviceInformation, dq)) 
         {
             Rssi = rssi;
             Id = id;


### PR DESCRIPTION
This PR does a couple of things:
* It updates Microsoft.Toolkit.Uwp.Connectivity from 6.1 to 7.1 (for the Xamarin.UWP case, for MAUI on Windows we already have CommunityToolkit.WinUI.Connectivity v7.1).
* It updates the minimum target platform version for Xamarin.UWP to 10.0.17763 (which is necessary for the above Toolkit version and matches what we already have for MAUI).
* It fixes the NullReferenceException from #356 by obtaining the DispatcherQueue on the UI thread.
* It also updates BLE.Client.UWP a bit.

I verified with BLE.Client.UWP that scanning on Windows works well, and I strongly assume that things should also work with MAUI now (this still needs confirmation, though).