### PR TITLE
Querying adapter capabilities: extended advertisements & coded phy

### DIFF
--- a/Source/Plugin.BLE/Android/Adapter.cs
+++ b/Source/Plugin.BLE/Android/Adapter.cs
@@ -290,6 +290,22 @@ namespace Plugin.BLE.Android
             }
         }
 
+        public override bool supportsCodedPHY()
+        {
+#if NET6_0_OR_GREATER
+            if (OperatingSystem.IsAndroidVersionAtLeast(26))
+#else
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+#endif
+            {
+                return _bluetoothAdapter.IsLeCodedPhySupported;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
 
         private class DeviceComparer : IEqualityComparer<BluetoothDevice>
         {

--- a/Source/Plugin.BLE/Android/Adapter.cs
+++ b/Source/Plugin.BLE/Android/Adapter.cs
@@ -274,6 +274,23 @@ namespace Plugin.BLE.Android
             return devices.Where(item => ids.Contains(item.Id)).ToList();
         }
 
+        public override bool supportsExtendedAdvertising()
+        {
+#if NET6_0_OR_GREATER
+            if (OperatingSystem.IsAndroidVersionAtLeast(26))
+#else
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+#endif
+            {
+                return _bluetoothAdapter.IsLeExtendedAdvertisingSupported;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+
         private class DeviceComparer : IEqualityComparer<BluetoothDevice>
         {
             public bool Equals(BluetoothDevice x, BluetoothDevice y)

--- a/Source/Plugin.BLE/Apple/Adapter.cs
+++ b/Source/Plugin.BLE/Apple/Adapter.cs
@@ -422,5 +422,23 @@ namespace Plugin.BLE.iOS
 
             return records;
         }
+
+#if NET6_0_OR_GREATER || __IOS__
+        public override bool supportsExtendedAdvertising()
+        {
+#if NET6_0_OR_GREATER
+            if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13))
+#elif __IOS__
+            if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+#endif
+            {
+                return CBCentralManager.SupportsFeatures(CBCentralManagerFeature.ExtendedScanAndConnect);
+            }
+            else
+            {
+                return false;
+            }
+        }
+#endif
     }
 }

--- a/Source/Plugin.BLE/Shared/AdapterBase.cs
+++ b/Source/Plugin.BLE/Shared/AdapterBase.cs
@@ -361,5 +361,10 @@ namespace Plugin.BLE.Abstractions
         /// Indicates whether extended advertising (BLE5) is supported.
         /// </summary>
         public virtual bool supportsExtendedAdvertising() => false;
+
+        /// <summary>
+        /// Indicates whether the Coded PHY feature (BLE5) is supported.
+        /// </summary>
+        public virtual bool supportsCodedPHY() => false;
     }
 }

--- a/Source/Plugin.BLE/Shared/AdapterBase.cs
+++ b/Source/Plugin.BLE/Shared/AdapterBase.cs
@@ -356,5 +356,10 @@ namespace Plugin.BLE.Abstractions
         /// Returns a list of paired BLE devices for the given UUIDs.
         /// </summary>
         public abstract IReadOnlyList<IDevice> GetKnownDevicesByIds(Guid[] ids);
+
+        /// <summary>
+        /// Indicates whether extended advertising (BLE5) is supported.
+        /// </summary>
+        public virtual bool supportsExtendedAdvertising() => false;
     }
 }

--- a/Source/Plugin.BLE/Shared/Contracts/IAdapter.cs
+++ b/Source/Plugin.BLE/Shared/Contracts/IAdapter.cs
@@ -171,5 +171,11 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// </summary>
         /// <returns><c>true</c> if extended advertising is supported, otherwise <c>false</c>.</returns>
         bool supportsExtendedAdvertising();
+
+        /// <summary>
+        /// Indicates whether the Coded PHY feature (BLE5) is supported.
+        /// </summary>
+        /// <returns><c>true</c> if extended advertising is supported, otherwise <c>false</c>.</returns>
+        bool supportsCodedPHY();
     }
 }

--- a/Source/Plugin.BLE/Shared/Contracts/IAdapter.cs
+++ b/Source/Plugin.BLE/Shared/Contracts/IAdapter.cs
@@ -165,5 +165,11 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// <param name="ids">The list of UUIDs</param>
         /// <returns>The known device. Empty list if no device known.</returns>
         IReadOnlyList<IDevice> GetKnownDevicesByIds(Guid[] ids);
+
+        /// <summary>
+        /// Indicates whether extended advertising (BLE5) is supported.
+        /// </summary>
+        /// <returns><c>true</c> if extended advertising is supported, otherwise <c>false</c>.</returns>
+        bool supportsExtendedAdvertising();
     }
 }


### PR DESCRIPTION
This PR implements the major parts of issue #675, adding two new methods to the IAdapter interface:

* `supportsExtendedAdvertising`
* `supportsCodedPHY`

The first one has implementations on Android and iOS (and returns false on other platforms, such as MacOS and Windows), the second one is implemented only on Android.