### PR TITLE
Fix build on Mac

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,7 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+
+  winBuild:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
@@ -67,3 +68,24 @@ jobs:
       with:
         name: nupkg
         path: ./Source/*/nuget/*Plugin.BLE*.nupkg
+
+  macBuild:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: nuget/setup-nuget@v1
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
+    - name: Install .NET MAUI
+      run: |
+        dotnet nuget locals all --clear
+        dotnet workload install maui --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json
+        dotnet workload install android ios maccatalyst tvos macos maui wasm-tools maui-maccatalyst --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json
+    - name: Build Plugin.BLE NuGet
+      run: dotnet build ./Source/Plugin.BLE/Plugin.BLE.csproj /p:Configuration=Release /t:restore,build,pack /p:Version=$(git describe) /p:ContinuousIntegrationBuild=true /p:DeterministicSourcePaths=false
+    - name: Build MVVMCross.Plugins.BLE NuGet
+      run: dotnet build ./Source/MvvmCross.Plugins.BLE/MvvmCross.Plugins.BLE.csproj /p:Configuration=Release /t:restore,build,pack /p:Version=$(git describe) /p:ContinuousIntegrationBuild=true /p:DeterministicSourcePaths=false

--- a/Source/BLE.Mac.slnf
+++ b/Source/BLE.Mac.slnf
@@ -5,10 +5,7 @@
       "Plugin.BLE\\Plugin.BLE.csproj",
       "Plugin.BLE.Tests\\Plugin.BLE.Tests.csproj",
       "MvvmCross.Plugins.BLE\\MvvmCross.Plugins.BLE.csproj",
-      "BLE.Client\\BLE.Client\\BLE.Client.csproj",
-      "BLE.Client\\BLE.Client.Droid\\BLE.Client.Droid.csproj",
-      "BLE.Client\\BLE.Client.iOS\\BLE.Client.iOS.csproj",
-      "BLE.Client\\BLE.Client.macOS\\BLE.Client.macOS.csproj"
+      "BLE.Client\\BLE.Client\\BLE.Client.csproj"
     ]
   }
 }

--- a/Source/MvvmCross.Plugins.BLE/MvvmCross.Plugins.BLE.csproj
+++ b/Source/MvvmCross.Plugins.BLE/MvvmCross.Plugins.BLE.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
 	<PropertyGroup>
-		<TargetFrameworks>MonoAndroid10.0;Xamarin.iOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-maccatalyst;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.19041;net6.0-windows10.0.19041;net7.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);MonoAndroid10.0;Xamarin.iOS10;Xamarin.Mac20;uap10.0.19041;net6.0-windows10.0.19041;net7.0-windows10.0.19041</TargetFrameworks>
 		<AssemblyName>MVVMCross.Plugins.BLE</AssemblyName>
 		<RootNamespace>MVVMCross.Plugins.BLE</RootNamespace>
 		<Version>3.0.0-beta.3</Version>

--- a/Source/Plugin.BLE/Plugin.BLE.csproj
+++ b/Source/Plugin.BLE/Plugin.BLE.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;MonoAndroid10.0;Xamarin.iOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-maccatalyst;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.19041;net6.0-windows10.0.19041;net7.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0-android;net6.0-ios;net6.0-maccatalyst;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);MonoAndroid10.0;Xamarin.iOS10;Xamarin.Mac20;uap10.0.19041;net6.0-windows10.0.19041;net7.0-windows10.0.19041</TargetFrameworks>
 		<AssemblyName>Plugin.BLE</AssemblyName>
 		<RootNamespace>Plugin.BLE</RootNamespace>
 		<Version>3.0.0-beta.3</Version>


### PR DESCRIPTION
This should fix #683, essentially by building only the MAUI parts on Mac, but not the Xamarin parts, since mixed Xamarin/MAUI builds seem to be broken on Mac.
Furthermore I'm adding a Mac build to the Gihub Actions CI, which verifies that building on Mac works (at least the core libs).