### PR TITLE
Bonding on Android

### DIFF
--- a/Source/Plugin.BLE/Android/Device.cs
+++ b/Source/Plugin.BLE/Android/Device.cs
@@ -35,6 +35,8 @@ namespace Plugin.BLE.Android
         /// the registration must be disposed to avoid disconnecting after a connection
         /// </summary>
         private CancellationTokenRegistration _connectCancellationTokenRegistration;
+        
+        private TaskCompletionSource<bool> _bondCompleteTaskCompletionSource;
 
         /// <summary>
         /// the connect paramaters used when connecting to this device
@@ -142,6 +144,23 @@ namespace Plugin.BLE.Android
                 _connectCancellationTokenRegistration.Dispose();
                 _connectCancellationTokenRegistration = cancellationToken.Register(() => DisconnectAndClose(connectGatt));
             }
+        }
+
+        public Task BondAsync()
+        {
+            _bondCompleteTaskCompletionSource = new TaskCompletionSource<bool>();
+            NativeDevice.CreateBond();
+            return _bondCompleteTaskCompletionSource.Task;
+        }
+
+        internal void SetBondState(DeviceBondState state)
+        {
+            if (state != DeviceBondState.Bonded)
+            {
+                return;
+            }
+
+            _bondCompleteTaskCompletionSource?.TrySetResult(true);
         }
 
         private void ConnectToGattForceBleTransportAPI(bool autoconnect, CancellationToken cancellationToken)

--- a/Source/Plugin.BLE/Apple/Adapter.cs
+++ b/Source/Plugin.BLE/Apple/Adapter.cs
@@ -149,6 +149,11 @@ namespace Plugin.BLE.iOS
                 };
         }
 
+        public override Task BondAsync(IDevice device)
+        {
+            throw new NotSupportedException();
+        }
+
         protected override async Task StartScanningForDevicesNativeAsync(ScanFilterOptions scanFilterOptions, bool allowDuplicatesKey, CancellationToken scanCancellationToken)
         {
 #if NET6_0_OR_GREATER || MACCATALYST

--- a/Source/Plugin.BLE/Shared/AdapterBase.cs
+++ b/Source/Plugin.BLE/Shared/AdapterBase.cs
@@ -327,6 +327,8 @@ namespace Plugin.BLE.Abstractions
             });
         }
 
+        public abstract Task BondAsync(IDevice device);
+
         /// <summary>
         /// Native implementation of StartScanningForDevicesAsync.
         /// </summary>

--- a/Source/Plugin.BLE/Shared/Contracts/IAdapter.cs
+++ b/Source/Plugin.BLE/Shared/Contracts/IAdapter.cs
@@ -76,6 +76,8 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// </summary>
         IReadOnlyList<IDevice> ConnectedDevices { get; }
 
+        public Task BondAsync(IDevice device);
+
         /// <summary>
         /// Starts scanning for BLE devices that fulfill the <paramref name="deviceFilter"/>.
         /// DeviceDiscovered will only be called, if <paramref name="deviceFilter"/> returns <c>true</c> for the discovered device.

--- a/Source/Plugin.BLE/Shared/EventArgs/DeviceBondStateChangedEventArgs.cs
+++ b/Source/Plugin.BLE/Shared/EventArgs/DeviceBondStateChangedEventArgs.cs
@@ -10,7 +10,7 @@ namespace Plugin.BLE.Abstractions.EventArgs
         /// <summary>
         /// The device.
         /// </summary>
-        public IDevice Device { get; set; }
+        public string Address { get; set; }
         /// <summary>
         /// The bond state.
         /// </summary>

--- a/Source/Plugin.BLE/Shared/Utils/FakeAdapter.cs
+++ b/Source/Plugin.BLE/Shared/Utils/FakeAdapter.cs
@@ -14,6 +14,11 @@ namespace Plugin.BLE.Abstractions.Utils
             return Task.FromResult<IDevice>(null);
         }
 
+        public override Task BondAsync(IDevice device)
+        {
+            return Task.FromResult(0);
+        }
+
         protected override Task StartScanningForDevicesNativeAsync(ScanFilterOptions scanFilterOptions, bool allowDuplicatesKey, CancellationToken scanCancellationToken)
         {
             TraceUnavailability();

--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -34,6 +34,11 @@ namespace Plugin.BLE.UWP
             _dq = DispatcherQueue.GetForCurrentThread();
         }
 
+        public override Task BondAsync(IDevice device)
+        {
+            throw new NotImplementedException();
+        }
+
         protected override Task StartScanningForDevicesNativeAsync(ScanFilterOptions scanFilterOptions, bool allowDuplicatesKey, CancellationToken scanCancellationToken)
         {
             var serviceUuids = scanFilterOptions?.ServiceUuids;


### PR DESCRIPTION
This enables bonding on Android, which is now required to workaround what appears to be an Android bug causing the pairing dialog to appear twice.  It's possible there should be some sort of IsBondingSupported property as well, as bonding isn't supported on iOS or (I believe) UWP.