### PR TITLE
Fix  DisconnectAsync hangs on Windows and Android after scanning then…

### DIFF
--- a/Source/Plugin.BLE/Android/Adapter.cs
+++ b/Source/Plugin.BLE/Android/Adapter.cs
@@ -242,11 +242,12 @@ namespace Plugin.BLE.Android
             ((Device)device).Disconnect();
         }
 
-        public override async Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task<IDevice> ConnectToKnownDeviceNativeAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken))
         {
             var macBytes = deviceGuid.ToByteArray().Skip(10).Take(6).ToArray();
             var nativeDevice = _bluetoothAdapter.GetRemoteDevice(macBytes);
-
+            if (nativeDevice == null)
+                throw new Abstractions.Exceptions.DeviceConnectionException(deviceGuid,"", $"[Adapter] Device {deviceGuid} not found.");
             var device = new Device(this, nativeDevice, null);
 
             await ConnectToDeviceAsync(device, connectParameters, cancellationToken);

--- a/Source/Plugin.BLE/Android/Adapter.cs
+++ b/Source/Plugin.BLE/Android/Adapter.cs
@@ -244,6 +244,12 @@ namespace Plugin.BLE.Android
 
         public override async Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (DiscoveredDevicesRegistry.TryGetValue(deviceGuid, out IDevice discoveredDevice))
+            {
+                await ConnectToDeviceAsync(discoveredDevice, connectParameters, cancellationToken);
+                return discoveredDevice;
+            }
+
             var macBytes = deviceGuid.ToByteArray().Skip(10).Take(6).ToArray();
             var nativeDevice = _bluetoothAdapter.GetRemoteDevice(macBytes);
 

--- a/Source/Plugin.BLE/Android/Adapter.cs
+++ b/Source/Plugin.BLE/Android/Adapter.cs
@@ -244,12 +244,6 @@ namespace Plugin.BLE.Android
 
         public override async Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (DiscoveredDevicesRegistry.TryGetValue(deviceGuid, out IDevice discoveredDevice))
-            {
-                await ConnectToDeviceAsync(discoveredDevice, connectParameters, cancellationToken);
-                return discoveredDevice;
-            }
-
             var macBytes = deviceGuid.ToByteArray().Skip(10).Take(6).ToArray();
             var nativeDevice = _bluetoothAdapter.GetRemoteDevice(macBytes);
 

--- a/Source/Plugin.BLE/Apple/Adapter.cs
+++ b/Source/Plugin.BLE/Apple/Adapter.cs
@@ -220,7 +220,7 @@ namespace Plugin.BLE.iOS
         /// </summary>
         /// <returns>The to known device async.</returns>
         /// <param name="deviceGuid">Device GUID.</param>
-        public override async Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task<IDevice> ConnectToKnownDeviceNativeAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken))
         {
 #if NET6_0_OR_GREATER || MACCATALYST
             await WaitForState(CBManagerState.PoweredOn, cancellationToken, true);
@@ -230,7 +230,7 @@ namespace Plugin.BLE.iOS
 #endif
 
             if (cancellationToken.IsCancellationRequested)
-                throw new TaskCanceledException("ConnectToKnownDeviceAsync cancelled");
+                throw new TaskCanceledException("ConnectToKnownDeviceNativeAsync cancelled");
 
             //FYI attempted to use tobyte array insetead of string but there was a problem with byte ordering Guid->NSUui
             var uuid = new NSUuid(deviceGuid.ToString());
@@ -256,7 +256,7 @@ namespace Plugin.BLE.iOS
                 );
 
                 if (peripherial == null)
-                    throw new Exception($"[Adapter] Device {deviceGuid} not found.");
+                    throw new Abstractions.Exceptions.DeviceConnectionException(deviceGuid, "", $"[Adapter] Device {deviceGuid} not found.");
             }
 
 

--- a/Source/Plugin.BLE/Shared/AdapterBase.cs
+++ b/Source/Plugin.BLE/Shared/AdapterBase.cs
@@ -328,6 +328,24 @@ namespace Plugin.BLE.Abstractions
         }
 
         /// <summary>
+        /// Connects to a device with a known GUID without scanning and if in range. Does not scan for devices.
+        /// </summary>
+        public async Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default, CancellationToken cancellationToken = default)
+        {
+            if (DiscoveredDevicesRegistry.TryGetValue(deviceGuid, out IDevice discoveredDevice))
+            {
+                await ConnectToDeviceAsync(discoveredDevice, connectParameters, cancellationToken);
+                return discoveredDevice;
+            }
+
+            var connectedDevice = await ConnectToKnownDeviceNativeAsync(deviceGuid, connectParameters, cancellationToken);
+            if (!DiscoveredDevicesRegistry.ContainsKey(deviceGuid)) 
+                DiscoveredDevicesRegistry.TryAdd(deviceGuid, connectedDevice);
+
+            return connectedDevice;
+        }
+
+        /// <summary>
         /// Native implementation of StartScanningForDevicesAsync.
         /// </summary>
         protected abstract Task StartScanningForDevicesNativeAsync(ScanFilterOptions scanFilterOptions, bool allowDuplicatesKey, CancellationToken scanCancellationToken);
@@ -345,9 +363,9 @@ namespace Plugin.BLE.Abstractions
         protected abstract void DisconnectDeviceNative(IDevice device);
 
         /// <summary>
-        /// Connects to a device with a known GUID without scanning and if in range. Does not scan for devices.
+        /// Native implementation of ConnectToKnownDeviceAsync.
         /// </summary>
-        public abstract Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default, CancellationToken cancellationToken = default);
+        public abstract Task<IDevice> ConnectToKnownDeviceNativeAsync(Guid deviceGuid, ConnectParameters connectParameters = default, CancellationToken cancellationToken = default);
         /// <summary>
         /// Returns all BLE devices connected to the system.
         /// </summary>

--- a/Source/Plugin.BLE/Shared/Utils/FakeAdapter.cs
+++ b/Source/Plugin.BLE/Shared/Utils/FakeAdapter.cs
@@ -8,7 +8,7 @@ namespace Plugin.BLE.Abstractions.Utils
 {
     internal class FakeAdapter : AdapterBase
     {
-        public override Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters, CancellationToken cancellationToken)
+        public override Task<IDevice> ConnectToKnownDeviceNativeAsync(Guid deviceGuid, ConnectParameters connectParameters, CancellationToken cancellationToken)
         {
             TraceUnavailability();
             return Task.FromResult<IDevice>(null);

--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -171,12 +171,15 @@ namespace Plugin.BLE.UWP
             }
         }
 
-        public override async Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default, CancellationToken cancellationToken = default)
+        public override async Task<IDevice> ConnectToKnownDeviceNativeAsync(Guid deviceGuid, ConnectParameters connectParameters = default, CancellationToken cancellationToken = default)
         {
             //convert GUID to string and take last 12 characters as MAC address
             var guidString = deviceGuid.ToString("N").Substring(20);
             var bluetoothAddress = Convert.ToUInt64(guidString, 16);
             var nativeDevice = await BluetoothLEDevice.FromBluetoothAddressAsync(bluetoothAddress);
+            if (nativeDevice == null)
+                throw new Abstractions.Exceptions.DeviceConnectionException(deviceGuid, "", $"[Adapter] Device {deviceGuid} not found.");
+
             var knownDevice = new Device(this, nativeDevice, 0, deviceGuid, _dq);
 
             await ConnectToDeviceAsync(knownDevice, cancellationToken: cancellationToken);

--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -174,6 +174,12 @@ namespace Plugin.BLE.UWP
         public override async Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default, CancellationToken cancellationToken = default)
         {
             //convert GUID to string and take last 12 characters as MAC address
+            if (DiscoveredDevicesRegistry.TryGetValue(deviceGuid, out IDevice discoveredDevice))
+            {
+                await ConnectToDeviceAsync(discoveredDevice, connectParameters, cancellationToken);
+                return discoveredDevice;
+            }
+
             var guidString = deviceGuid.ToString("N").Substring(20);
             var bluetoothAddress = Convert.ToUInt64(guidString, 16);
             var nativeDevice = await BluetoothLEDevice.FromBluetoothAddressAsync(bluetoothAddress);

--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -174,12 +174,6 @@ namespace Plugin.BLE.UWP
         public override async Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default, CancellationToken cancellationToken = default)
         {
             //convert GUID to string and take last 12 characters as MAC address
-            if (DiscoveredDevicesRegistry.TryGetValue(deviceGuid, out IDevice discoveredDevice))
-            {
-                await ConnectToDeviceAsync(discoveredDevice, connectParameters, cancellationToken);
-                return discoveredDevice;
-            }
-
             var guidString = deviceGuid.ToString("N").Substring(20);
             var bluetoothAddress = Convert.ToUInt64(guidString, 16);
             var nativeDevice = await BluetoothLEDevice.FromBluetoothAddressAsync(bluetoothAddress);


### PR DESCRIPTION
… connecting with ConnectToKnownDeviceAsync #734

In the native Windows and Android adapter, it always create a new native `IDevice` instance when using `ConnectToKnownDeviceAsync` if the device has already been discovered via scanning you end up with two `IDevice` instances.  If the user then calls `DisconnectDeviceAsync` on the `IDevice` instance that was discovered via scanning, this issue occurs.

I DID NOT check the other platform adapters so this issue may be present in other platforms.  The solution is easy; just check the `DiscoveredDevicesRegistry` before creating a new `Device` instance.