### PR TITLE
Fix GHA failures

### DIFF
--- a/.build/build.cake
+++ b/.build/build.cake
@@ -1,5 +1,5 @@
-#addin nuget:?package=Cake.Git&version=2.0.0
-#addin nuget:?package=Cake.FileHelpers&version=5.0.0
+#addin nuget:?package=Cake.Git&version=3.0.0
+#addin nuget:?package=Cake.FileHelpers&version=6.1.3
 
 using Path = System.IO.Path;
 using System.Xml.Linq;

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 7.0.3xx
     - name: Install .NET MAUI
       shell: pwsh
       run: |


### PR DESCRIPTION
... by downgrading the .NET SDK from 7.0.400 to 7.0.30x.

This fixes the CI failures seen in all recents PRs (e.g. #730, #735, #736). Since I found no other way to fix the errors, this is my last resort (and should only be a temporary measure).

The failures appeared when the SDK version on the build host was upgraded to 7.0.400. I still don't fully understand the problem. It might possibly be a bug in the 7.0.400 tooling (or at least a change in behavior).

Other things that I have tried (but did not help):
* getting rid of cake
* removing the net6.0 targets
