### PR TITLE
ReadAsync updates characteristic value on Windows

### DIFF
--- a/Source/Plugin.BLE/Windows/Characteristic.cs
+++ b/Source/Plugin.BLE/Windows/Characteristic.cs
@@ -50,7 +50,7 @@ namespace Plugin.BLE.UWP
         protected override async Task<(byte[] data, int resultCode)> ReadNativeAsync()
         {
             var readResult = await NativeCharacteristic.ReadValueAsync(BleImplementation.CacheModeCharacteristicRead);
-            var _value = readResult.GetValueOrThrowIfError();
+            _value = readResult.GetValueOrThrowIfError();
             return (_value, (int)readResult.Status);
         }
 


### PR DESCRIPTION
On Android calling ReadAsync on a Characteristic also updates it's Value. However this doesn't occur in Windows builds. The name of the local variable leads me to think this was a typo and updating the Value is the intended behaviour.