### PR TITLE
Remove .NET 6

### DIFF
--- a/Source/MvvmCross.Plugins.BLE/MvvmCross.Plugins.BLE.csproj
+++ b/Source/MvvmCross.Plugins.BLE/MvvmCross.Plugins.BLE.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-android33.0;net6.0-ios;net6.0-maccatalyst;net7.0-android33.0;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net7.0-android33.0;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;uap10.0.19041;net6.0-windows10.0.19041;net7.0-windows10.0.19041</TargetFrameworks>
 		<AssemblyName>MVVMCross.Plugins.BLE</AssemblyName>
 		<RootNamespace>MVVMCross.Plugins.BLE</RootNamespace>

--- a/Source/MvvmCross.Plugins.BLE/MvvmCross.Plugins.BLE.csproj
+++ b/Source/MvvmCross.Plugins.BLE/MvvmCross.Plugins.BLE.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
 	<PropertyGroup>
 		<TargetFrameworks>net7.0-android33.0;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;uap10.0.19041;net6.0-windows10.0.19041;net7.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;uap10.0.19041;net7.0-windows10.0.19041</TargetFrameworks>
 		<AssemblyName>MVVMCross.Plugins.BLE</AssemblyName>
 		<RootNamespace>MVVMCross.Plugins.BLE</RootNamespace>
 		<Version>3.0.0</Version>

--- a/Source/Plugin.BLE/Plugin.BLE.csproj
+++ b/Source/Plugin.BLE/Plugin.BLE.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net7.0-android33.0;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;uap10.0.19041;net6.0-windows10.0.19041;net7.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;uap10.0.19041;net7.0-windows10.0.19041</TargetFrameworks>
 		<AssemblyName>Plugin.BLE</AssemblyName>
 		<RootNamespace>Plugin.BLE</RootNamespace>
 		<Version>3.0.0</Version>

--- a/Source/Plugin.BLE/Plugin.BLE.csproj
+++ b/Source/Plugin.BLE/Plugin.BLE.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6.0-android33.0;net6.0-ios;net6.0-maccatalyst;net7.0-android33.0;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net7.0-android33.0;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;uap10.0.19041;net6.0-windows10.0.19041;net7.0-windows10.0.19041</TargetFrameworks>
 		<AssemblyName>Plugin.BLE</AssemblyName>
 		<RootNamespace>Plugin.BLE</RootNamespace>
@@ -75,11 +75,11 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
-		<Compile Include="**\Windows\**\*.cs" />		
+		<Compile Include="**\Windows\**\*.cs" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.Contains('-windows')) ">
-		<Compile Include="**\Windows\**\*.cs" />		
+		<Compile Include="**\Windows\**\*.cs" />
 	</ItemGroup>
 
 	<PropertyGroup Condition=" $(TargetFramework.Contains('-android')) ">


### PR DESCRIPTION
Rationale:
* .NET 6 Maui (including the Android, iOS and Maccatalyst targets) is not supported any more, which generates lots of warnings in our builds.
* .NET 6 in general (with the Windows target) is still supported for another year in principle. But since Plugin.BLE is a cross-platform library, I see little incentive for keeping the Windows target of .NET 6 only.
* Of course the .NET 7 targets continue to be available, and .NET 8 will be added soon.

References:
* https://dotnet.microsoft.com/en-us/platform/support/policy/maui
* https://dotnet.microsoft.com/en-us/platform/support/policy