### PR TITLE
Improve Connect In Windows

### DIFF
--- a/Source/BLE.Client/BLE.Client.WinConsole/ConsoleTracer.cs
+++ b/Source/BLE.Client/BLE.Client.WinConsole/ConsoleTracer.cs
@@ -47,6 +47,16 @@ namespace BLE.Client.WinConsole
             newEntry.Set();
         }
 
+        /// <summary>
+        /// Get a tracer with a prefix 
+        /// </summary>
+        /// <param name="prefix"></param>
+        /// <returns></returns>
+        public Action<string, object[]> GetPrefixedTrace(string prefix)
+        {
+            return new Action<string, object[]>((format, args) => Trace(prefix + " - " + format, args));
+        }
+
         void WriteWorker()
         {
             while (!disposing && newEntry.WaitOne())
@@ -57,7 +67,7 @@ namespace BLE.Client.WinConsole
                     Console.WriteLine(entry.Time.ToString("HH:mm:ss.fff ") + entry.Format + " ", entry.Args);
                 }
             }
-            Console.WriteLine("Bye bye says the Console Tracer.");
+            Console.WriteLine("Console Tracer is Finished.");
         }
 
         private DateTime GetTime()
@@ -67,8 +77,9 @@ namespace BLE.Client.WinConsole
 
         public void Dispose()
         {
-            disposing = true;            
-            worker.Wait(1000);
+            disposing = true;
+            newEntry.Set();
+            worker.Wait(100);
         }
     }
 }

--- a/Source/BLE.Client/BLE.Client.WinConsole/Program.cs
+++ b/Source/BLE.Client/BLE.Client.WinConsole/Program.cs
@@ -1,13 +1,14 @@
 ﻿using BLE.Client.WinConsole;
 using Plugin.BLE;
 using Plugin.BLE.Abstractions.Contracts;
+using System;
 
 Console.WriteLine("Hello, BLE World!");
-var ct = new ConsoleTracer();
-Plugin.BLE.Abstractions.Trace.TraceImplementation = ct.Trace;
-var demo = new BleDemo(ct.Trace);
-await demo.DoTheScanning(ScanMode.LowPower);
-await demo.ConnectTest("Shure");
-ct.Dispose();
+using (var ct = new ConsoleTracer())
+{
+    Plugin.BLE.Abstractions.Trace.TraceImplementation = ct.GetPrefixedTrace("Plugin.BLE");
+    var demo = new BleDemo(ct.GetPrefixedTrace("      DEMO"));
+    await demo.ShowNumberOfServices("40CBC0DD37E2");
+}
 
 

--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -11,7 +11,6 @@ using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Extensions;
 using System.Collections.Concurrent;
 using Windows.Devices.Enumeration;
-using WBluetooth = global::Windows.Devices.Bluetooth;
 
 namespace Plugin.BLE.Windows
 {
@@ -83,22 +82,6 @@ namespace Plugin.BLE.Windows
             nativeDevice.ConnectionStatusChanged -= Device_ConnectionStatusChanged;
             nativeDevice.ConnectionStatusChanged += Device_ConnectionStatusChanged;
 
-            // Calling the GetGattServicesAsync on the BluetoothLEDevice with uncached property causes the device to connect
-            //
-            // ref https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothledevice.frombluetoothaddressasync
-            // Creating a BluetoothLEDevice object by calling this method alone doesn't (necessarily) initiate a connection.
-            // To initiate a connection, set GattSession.MaintainConnection to true, or call an uncached service discovery
-            // method on BluetoothLEDevice, or perform a read/write operation against the device.
-            //
-            // Remark from Ask Bojesen 2023-11-12:
-            // Below three lines reflect the different approach with GattSession, but I could not get this working properly 
-            //
-            // var deviceId = BluetoothDeviceId.FromId(dev.NativeDevice.DeviceId);            
-            // var genericProfileGattSession = await GattSession.FromDeviceIdAsync(deviceId);            
-            // bool success = genericProfileGattSession.MaintainConnection = true;
-
-            //var servicesResult = await dev.NativeDevice.GetGattServicesAsync(BluetoothCacheMode.Uncached);
-            //bool success = servicesResult.Status == WBluetooth.GenericAttributeProfile.GattCommunicationStatus.Success;
             bool success = await dev.ConnectInternal(connectParameters, cancellationToken);
 
             if (!success)            

--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -84,7 +84,7 @@ namespace Plugin.BLE.Windows
 
             bool success = await dev.ConnectInternal(connectParameters, cancellationToken);
 
-            if (!success)            
+            if (!success)
             {
                 // use DisconnectDeviceNative to clean up resources otherwise windows won't disconnect the device
                 // after a subsequent successful connection (#528, #536, #423)
@@ -149,7 +149,7 @@ namespace Plugin.BLE.Windows
         protected override void DisconnectDeviceNative(IDevice device)
         {
             // Windows doesn't support disconnecting, so currently just dispose of the device
-            Trace.Message($"DisconnectDeviceNative from device with ID:  {device.Id.ToHexBleAddress()}");            
+            Trace.Message($"DisconnectDeviceNative from device with ID:  {device.Id.ToHexBleAddress()}");
             if (device.NativeDevice is BluetoothLEDevice nativeDevice)
             {
                 _deviceOperationRegistry.Remove(device.Id.ToString());

--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -97,10 +97,11 @@ namespace Plugin.BLE.Windows
             // var genericProfileGattSession = await GattSession.FromDeviceIdAsync(deviceId);            
             // bool success = genericProfileGattSession.MaintainConnection = true;
 
-            var servicesResult = await dev.NativeDevice.GetGattServicesAsync(BluetoothCacheMode.Uncached);
+            //var servicesResult = await dev.NativeDevice.GetGattServicesAsync(BluetoothCacheMode.Uncached);
+            //bool success = servicesResult.Status == WBluetooth.GenericAttributeProfile.GattCommunicationStatus.Success;
+            bool success = await dev.ConnectInternal(connectParameters, cancellationToken);
 
-            if (servicesResult.Status != WBluetooth.GenericAttributeProfile.GattCommunicationStatus.Success
-                || nativeDevice.ConnectionStatus != BluetoothConnectionStatus.Connected)
+            if (!success)            
             {
                 // use DisconnectDeviceNative to clean up resources otherwise windows won't disconnect the device
                 // after a subsequent successful connection (#528, #536, #423)
@@ -165,12 +166,11 @@ namespace Plugin.BLE.Windows
         protected override void DisconnectDeviceNative(IDevice device)
         {
             // Windows doesn't support disconnecting, so currently just dispose of the device
-            Trace.Message($"DisconnectDeviceNative from device with ID:  {device.Id.ToHexBleAddress()}");
+            Trace.Message($"DisconnectDeviceNative from device with ID:  {device.Id.ToHexBleAddress()}");            
             if (device.NativeDevice is BluetoothLEDevice nativeDevice)
             {
                 _deviceOperationRegistry.Remove(device.Id.ToString());
-                ((Device)device).ClearServices();
-                ((Device)device).DisposeNativeDevice();
+                ((Device)device).DisconnectInternal();
             }
         }
 

--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -84,11 +84,21 @@ namespace Plugin.BLE.Windows
             nativeDevice.ConnectionStatusChanged += Device_ConnectionStatusChanged;
 
             // Calling the GetGattServicesAsync on the BluetoothLEDevice with uncached property causes the device to connect
+            //
             // ref https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothledevice.frombluetoothaddressasync
             // Creating a BluetoothLEDevice object by calling this method alone doesn't (necessarily) initiate a connection.
             // To initiate a connection, set GattSession.MaintainConnection to true, or call an uncached service discovery
             // method on BluetoothLEDevice, or perform a read/write operation against the device.
+            //
+            // Remark from Ask Bojesen 2023-11-12:
+            // Below three lines reflect the different approach with GattSession, but I could not get this working properly 
+            //
+            // var deviceId = BluetoothDeviceId.FromId(dev.NativeDevice.DeviceId);            
+            // var genericProfileGattSession = await GattSession.FromDeviceIdAsync(deviceId);            
+            // bool success = genericProfileGattSession.MaintainConnection = true;
+
             var servicesResult = await dev.NativeDevice.GetGattServicesAsync(BluetoothCacheMode.Uncached);
+
             if (servicesResult.Status != WBluetooth.GenericAttributeProfile.GattCommunicationStatus.Success
                 || nativeDevice.ConnectionStatus != BluetoothConnectionStatus.Connected)
             {

--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -84,6 +84,10 @@ namespace Plugin.BLE.Windows
             nativeDevice.ConnectionStatusChanged += Device_ConnectionStatusChanged;
 
             // Calling the GetGattServicesAsync on the BluetoothLEDevice with uncached property causes the device to connect
+            // ref https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothledevice.frombluetoothaddressasync
+            // Creating a BluetoothLEDevice object by calling this method alone doesn't (necessarily) initiate a connection.
+            // To initiate a connection, set GattSession.MaintainConnection to true, or call an uncached service discovery
+            // method on BluetoothLEDevice, or perform a read/write operation against the device.
             var servicesResult = await dev.NativeDevice.GetGattServicesAsync(BluetoothCacheMode.Uncached);
             if (servicesResult.Status != WBluetooth.GenericAttributeProfile.GattCommunicationStatus.Success
                 || nativeDevice.ConnectionStatus != BluetoothConnectionStatus.Connected)

--- a/Source/Plugin.BLE/Windows/Device.cs
+++ b/Source/Plugin.BLE/Windows/Device.cs
@@ -117,7 +117,11 @@ namespace Plugin.BLE.Windows
         }
 
         public async Task<bool> ConnectInternal(ConnectParameters connectParameters, CancellationToken cancellationToken)
-        {            
+        {
+            // ref https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothledevice.frombluetoothaddressasync
+            // Creating a BluetoothLEDevice object by calling this method alone doesn't (necessarily) initiate a connection.
+            // To initiate a connection, set GattSession.MaintainConnection to true, or call an uncached service discovery
+            // method on BluetoothLEDevice, or perform a read/write operation against the device.            
             this.connectParameters = connectParameters;
             if (NativeDevice is null)
             {
@@ -127,7 +131,7 @@ namespace Plugin.BLE.Windows
             try
             {
                 var devId = BluetoothDeviceId.FromId(NativeDevice.DeviceId);
-                gattSession = await WBluetooth.GenericAttributeProfile.GattSession.FromDeviceIdAsync(devId);                
+                gattSession = await GattSession.FromDeviceIdAsync(devId);                
                 gattSession.SessionStatusChanged += GattSession_SessionStatusChanged;
                 gattSession.MaintainConnection = true;
             } catch (Exception ex)

--- a/Source/Plugin.BLE/Windows/Device.cs
+++ b/Source/Plugin.BLE/Windows/Device.cs
@@ -110,7 +110,7 @@ namespace Plugin.BLE.Windows
             if (gattSession is null)
             {
                 Trace.Message("WARNING RequestMtuNativeAsync failed since gattSession is null");
-                return -1; 
+                return -1;
             }
             return gattSession.MaxPduSize;
         }


### PR DESCRIPTION
In the Windows implementation, the ConnectToDeviceNativeAsync method did not work properly.
It was especially seen in the case when:

1. Connect
2. Get services
3. Disconnect
4. Connect
5. Get services

This has now been solved