### PR TITLE
Scan Response Advertisement Records Implemented in Windows

### DIFF
--- a/Source/BLE.Client/BLE.Client.WinConsole/BLE.Client.WinConsole.csproj
+++ b/Source/BLE.Client/BLE.Client.WinConsole/BLE.Client.WinConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Source/Plugin.BLE/Shared/Contracts/IDevice.cs
+++ b/Source/Plugin.BLE/Shared/Contracts/IDevice.cs
@@ -48,6 +48,15 @@ namespace Plugin.BLE.Abstractions.Contracts
         IReadOnlyList<AdvertisementRecord> AdvertisementRecords { get; }
 
         /// <summary>
+        /// All the advertisment records received as scan responses
+        /// For example:
+        /// - Advertised Service UUIDS
+        /// - Manufacturer Specifc data
+        /// - ...
+        /// </summary>
+        IReadOnlyList<AdvertisementRecord> ScanResponseAdvertisementRecords { get; }
+
+        /// <summary>
         /// Gets all services of the device.
         /// </summary>
         /// <param name="cancellationToken"></param>
@@ -120,7 +129,7 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// True, if device supports IsConnectable else False
         /// </summary>
         bool SupportsIsConnectable { get; }
-        
+
         /// <summary>
         /// Gets the bonding state of a device.
         /// </summary>

--- a/Source/Plugin.BLE/Shared/DeviceBase.cs
+++ b/Source/Plugin.BLE/Shared/DeviceBase.cs
@@ -84,6 +84,10 @@ namespace Plugin.BLE.Abstractions
         /// </summary>
         public IReadOnlyList<AdvertisementRecord> AdvertisementRecords { get; protected set; }
         /// <summary>
+        /// All the advertisment records revived as scan responses.
+        /// </summary>
+        public IReadOnlyList<AdvertisementRecord> ScanResponseAdvertisementRecords { get; protected set; }        
+        /// <summary>
         /// The native device.
         /// </summary>
         public TNativeDevice NativeDevice { get; protected set; }
@@ -98,6 +102,8 @@ namespace Plugin.BLE.Abstractions
         {
             Adapter = adapter;
             NativeDevice = nativeDevice;
+            ScanResponseAdvertisementRecords = new List<AdvertisementRecord>();
+            AdvertisementRecords = new List<AdvertisementRecord>();
         }
 
         /// <summary>

--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -232,7 +232,14 @@ namespace Plugin.BLE.Windows
             if (DiscoveredDevicesRegistry.TryGetValue(deviceId, out var device) && device != null)
             {
                 Trace.Message("AdvReceived - Old: {0}", btAdv.ToDetailedString(device.Name));
-                (device as Device)?.Update(btAdv.RawSignalStrengthInDBm, ParseAdvertisementData(btAdv.Advertisement));
+                var advertisementRecords = ParseAdvertisementData(btAdv.Advertisement);
+                if (btAdv.AdvertisementType.HasFlag(BluetoothLEAdvertisementType.ScanResponse))
+                {
+                    (device as Device)?.UpdateScanResponseAdvertisementRecords(btAdv.RawSignalStrengthInDBm, advertisementRecords);
+                } else
+                {
+                    (device as Device)?.UpdateAdvertisementRecords(btAdv.RawSignalStrengthInDBm, advertisementRecords);
+                }
                 this.HandleDiscoveredDevice(device);
             }
             if (device == null)

--- a/Source/Plugin.BLE/Windows/Device.cs
+++ b/Source/Plugin.BLE/Windows/Device.cs
@@ -34,10 +34,16 @@ namespace Plugin.BLE.Windows
             IsConnectable = isConnectable;
         }
 
-        internal void Update(short btAdvRawSignalStrengthInDBm, IReadOnlyList<AdvertisementRecord> advertisementData)
+        internal void UpdateAdvertisementRecords(short btAdvRawSignalStrengthInDBm, IReadOnlyList<AdvertisementRecord> advertisementData)
         {
             this.Rssi = btAdvRawSignalStrengthInDBm;
             this.AdvertisementRecords = advertisementData;
+        }
+
+        internal void UpdateScanResponseAdvertisementRecords(short btAdvRawSignalStrengthInDBm, IReadOnlyList<AdvertisementRecord> advertisementData)
+        {
+            this.Rssi = btAdvRawSignalStrengthInDBm;
+            this.ScanResponseAdvertisementRecords = advertisementData;
         }
 
         public override Task<bool> UpdateRssiAsync()


### PR DESCRIPTION
We have a need to distinguish Advertisement Records  from a normal advertisement package and a scan response
This solves this need in Windows