### PR TITLE
Turn Bluetooth Radio On/Off

### DIFF
--- a/Source/Plugin.BLE/Android/BleImplementation.cs
+++ b/Source/Plugin.BLE/Android/BleImplementation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Android.App;
 using Android.Bluetooth;
 using Android.Content;
@@ -81,5 +82,11 @@ namespace Plugin.BLE
 
         protected override IAdapter CreateNativeAdapter()
             => new Adapter(_bluetoothManager);
+
+        public override Task<bool> TrySetStateAsync(bool on)
+        {
+            Abstractions.Trace.Message("WARNING TrySetStateAsync is not implemented for Android");
+            return Task<bool>.FromResult(false);
+        }
     }
 }

--- a/Source/Plugin.BLE/Apple/BleImplementation.cs
+++ b/Source/Plugin.BLE/Apple/BleImplementation.cs
@@ -4,6 +4,7 @@ using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Extensions;
 using Plugin.BLE.iOS;
+using System.Threading.Tasks;
 
 namespace Plugin.BLE
 {
@@ -60,6 +61,12 @@ namespace Plugin.BLE
 #endif
                 ShowPowerAlert = _showPowerAlert
             };
+        }
+
+        public override Task<bool> TrySetStateAsync(bool on)
+        {
+            Trace.Message("WARNING TrySetStateAsync is not implemented for Apple");
+            return Task<bool>.FromResult(false);
         }
     }
 }

--- a/Source/Plugin.BLE/Shared/BleImplementationBase.cs
+++ b/Source/Plugin.BLE/Shared/BleImplementationBase.cs
@@ -18,7 +18,6 @@ namespace Plugin.BLE.Abstractions
         /// Occurs when the state of the Bluetooth adapter changes.
         /// </summary>
         public event EventHandler<BluetoothStateChangedArgs> StateChanged;
-
         /// <summary>
         /// Indicates whether the device supports BLE.
         /// </summary>
@@ -72,23 +71,28 @@ namespace Plugin.BLE.Abstractions
                 return new FakeAdapter();
 
             return CreateNativeAdapter();
-        }        
+        }
 
         /// <summary>
         /// Native implementation of <c>Initialize</c>.
         /// </summary>
         protected abstract void InitializeNative();
-        
+
         /// <summary>
         /// Get initial state of native adapter.
         /// </summary>
         protected abstract BluetoothState GetInitialStateNative();
-        
+
         /// <summary>
         /// Create the native adapter.
         /// </summary>
         protected abstract IAdapter CreateNativeAdapter();
-        
+
+        /// <summary>
+        /// Try set the state of the Bluetooth on/off
+        /// </summary>
+        /// <param name="on"></param>
+        /// <returns>true if the the method executed with success otherwice false</returns>
         public abstract Task<bool> TrySetStateAsync(bool on);
     }
 }

--- a/Source/Plugin.BLE/Shared/BleImplementationBase.cs
+++ b/Source/Plugin.BLE/Shared/BleImplementationBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Abstractions.EventArgs;
 using Plugin.BLE.Abstractions.Utils;
@@ -71,19 +72,23 @@ namespace Plugin.BLE.Abstractions
                 return new FakeAdapter();
 
             return CreateNativeAdapter();
-        }
+        }        
 
         /// <summary>
         /// Native implementation of <c>Initialize</c>.
         /// </summary>
         protected abstract void InitializeNative();
+        
         /// <summary>
         /// Get initial state of native adapter.
         /// </summary>
         protected abstract BluetoothState GetInitialStateNative();
+        
         /// <summary>
         /// Create the native adapter.
         /// </summary>
         protected abstract IAdapter CreateNativeAdapter();
+        
+        public abstract Task<bool> TrySetStateAsync(bool on);
     }
 }

--- a/Source/Plugin.BLE/Shared/Contracts/IBluetoothLE.cs
+++ b/Source/Plugin.BLE/Shared/Contracts/IBluetoothLE.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Plugin.BLE.Abstractions.EventArgs;
 
 namespace Plugin.BLE.Abstractions.Contracts
@@ -28,6 +29,13 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// <c>true</c> if <see cref="State"/> is <c>BluetoothState.On</c>
         /// </summary>
         bool IsOn { get; }
+
+        /// <summary>
+        /// Try set the state of the Bluetooth on/off
+        /// </summary>
+        /// <param name="on"></param>
+        /// <returns>true if the the method executed with success otherwice false</returns>
+        Task<bool> TrySetStateAsync(bool on);
 
         /// <summary>
         /// Adapter to that provides access to the physical bluetooth adapter.

--- a/Source/Plugin.BLE/Shared/Contracts/IBluetoothLE.cs
+++ b/Source/Plugin.BLE/Shared/Contracts/IBluetoothLE.cs
@@ -32,6 +32,7 @@ namespace Plugin.BLE.Abstractions.Contracts
 
         /// <summary>
         /// Try set the state of the Bluetooth on/off
+        /// 2024-01-14: Only supported in Windows
         /// </summary>
         /// <param name="on"></param>
         /// <returns>true if the the method executed with success otherwice false</returns>

--- a/Source/Plugin.BLE/Windows/BleImplementation.cs
+++ b/Source/Plugin.BLE/Windows/BleImplementation.cs
@@ -71,12 +71,7 @@ namespace Plugin.BLE
             }
         }
 
-        /// <summary>
-        /// Try set the state of the Bluetooth on/off in Windows
-        /// </summary>
-        /// <param name="on"></param>
-        /// <returns>true if the the method executed with success otherwice false</returns>
-        public async Task<bool> TrySetStateAsync(bool on)
+        public override async Task<bool> TrySetStateAsync(bool on)
         {
             if (!isInitialized)
             {
@@ -88,7 +83,7 @@ namespace Plugin.BLE
             }
             catch (Exception ex)
             {
-                Trace.Message("TrySetStateAsync exception:{0}", ex.Message);
+                Trace.Message("TrySetStateAsync exception: {0}", ex.Message);
                 return false;
             }
         }

--- a/Source/Plugin.BLE/Windows/BleImplementation.cs
+++ b/Source/Plugin.BLE/Windows/BleImplementation.cs
@@ -10,6 +10,10 @@ namespace Plugin.BLE
 {
     public class BleImplementation : BleImplementationBase
     {
+        private BluetoothAdapter btAdapter;
+        private Radio radio;
+        private bool isInitialized = false;
+
         public static BluetoothCacheMode CacheModeCharacteristicRead { get; set; } = BluetoothCacheMode.Uncached;
         public static BluetoothCacheMode CacheModeDescriptorRead { get; set; } = BluetoothCacheMode.Uncached;
         public static BluetoothCacheMode CacheModeGetDescriptors { get; set; } = BluetoothCacheMode.Cached;
@@ -23,22 +27,15 @@ namespace Plugin.BLE
 
         protected override BluetoothState GetInitialStateNative()
         {
-            try
-            {                                
-                BluetoothAdapter btAdapter = BluetoothAdapter.GetDefaultAsync().AsTask().Result;
-                if (!btAdapter.IsLowEnergySupported)
-                {
-                    return BluetoothState.Unavailable;
-                }
-                var radio = btAdapter.GetRadioAsync().AsTask().Result;
-                radio.StateChanged += Radio_StateChanged;
-                return ToBluetoothState(radio.State);
-            }
-            catch (Exception ex) 
+            if (!isInitialized)
             {
-                Trace.Message("GetInitialStateNativeAsync exception:{0}", ex.Message);
+                return BluetoothState.Unknown;
+            }
+            if (!btAdapter.IsLowEnergySupported)
+            {
                 return BluetoothState.Unavailable;
             }
+            return ToBluetoothState(radio.State);
         }
 
         private static BluetoothState ToBluetoothState(RadioState radioState)
@@ -61,7 +58,39 @@ namespace Plugin.BLE
 
         protected override void InitializeNative()
         {
-            
+            try
+            {
+                btAdapter = BluetoothAdapter.GetDefaultAsync().AsTask().Result;
+                radio = btAdapter.GetRadioAsync().AsTask().Result;
+                radio.StateChanged += Radio_StateChanged;
+                isInitialized = true;
+            }
+            catch (Exception ex)
+            {
+                Trace.Message("InitializeNative exception:{0}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Try set the state of the Bluetooth on/off in Windows
+        /// </summary>
+        /// <param name="on"></param>
+        /// <returns>true if the the method executed with success otherwice false</returns>
+        public async Task<bool> TrySetStateAsync(bool on)
+        {
+            if (!isInitialized)
+            {
+                return false;
+            }
+            try
+            {
+                return await radio.SetStateAsync(on ? RadioState.On : RadioState.Off) == RadioAccessStatus.Allowed;
+            }
+            catch (Exception ex)
+            {
+                Trace.Message("TrySetStateAsync exception:{0}", ex.Message);
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
In the Windows Implementation I have added a `TrySetStateAsync`.
It works nicely in the Windows tool I have, but I guess security stuff doesn't allow this for Android + iOS, so I find no need to extend the interface,
but it is nice that the Windows implementation reuse the radio instance.