### PR TITLE
iOS.Device: update device name upon connecting to peripheral

### DIFF
--- a/Source/Plugin.BLE/Apple/Device.cs
+++ b/Source/Plugin.BLE/Apple/Device.cs
@@ -158,8 +158,7 @@ namespace Plugin.BLE.iOS
         public void Update(CBPeripheral nativeDevice)
         {
             Rssi = nativeDevice.RSSI?.Int32Value ?? 0;
-            //It's maybe not the best idea to updated the name based on CBPeripherial name because this might be stale.
-            //Name = nativeDevice.Name; 
+            Name = nativeDevice.Name;
         }
 
         protected override async Task<int> RequestMtuNativeAsync(int requestValue)


### PR DESCRIPTION
This is a second attempt to fix #541 and #703, following the first attempt in PR #711, which apparently was unsuccessful.