### PR TITLE
GHA: build Maui client on Windows

### DIFF
--- a/.build/build.cake
+++ b/.build/build.cake
@@ -76,6 +76,7 @@ Task("BuildClients")
   BuildProject("BLE.Client", "BLE.Client.UWP", Path.Combine("clients", "uwp"));
   // .NET 7/8
   BuildProject("BLE.Client", "BLE.Client.WinConsole", Path.Combine("clients", "wincon"));
+  BuildProject("BLE.Client", "BLE.Client.Maui", Path.Combine("clients", "maui"));
 });
 
 Task("Clean").Does (() =>

--- a/Source/BLE.Client/BLE.Client.Maui/BLE.Client.Maui.csproj
+++ b/Source/BLE.Client/BLE.Client.Maui/BLE.Client.Maui.csproj
@@ -9,6 +9,7 @@
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<PublishReadyToRun>false</PublishReadyToRun>
 
 		<!-- Display name -->
 		<ApplicationTitle>BLE.Client.Maui</ApplicationTitle>

--- a/Source/BLE.Client/BLE.Client.Maui/BLE.Client.Maui.csproj
+++ b/Source/BLE.Client/BLE.Client.Maui/BLE.Client.Maui.csproj
@@ -43,6 +43,7 @@
 		<PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
 	</PropertyGroup>
 	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+		<Platforms>x64</Platforms>
 		<RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
 	</PropertyGroup>
 

--- a/Source/BLE.Client/BLE.Client.Maui/BLE.Client.Maui.csproj
+++ b/Source/BLE.Client/BLE.Client.Maui/BLE.Client.Maui.csproj
@@ -42,9 +42,13 @@
 		<CodesignKey>Mac Developer</CodesignKey>
 		<PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
 	</PropertyGroup>
-	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+	<PropertyGroup Condition="$(TargetFramework.Contains('-windows')) and $(PlatformTarget)=='x64'">
 		<Platforms>x64</Platforms>
-		<RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+		<RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(TargetFramework.Contains('-windows')) and $(PlatformTarget)=='x86'">
+		<Platforms>x86</Platforms>
+		<RuntimeIdentifier>win10-x86</RuntimeIdentifier>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Source/BLE.Client/BLE.Client.Maui/BLE.Client.Maui.csproj
+++ b/Source/BLE.Client/BLE.Client.Maui/BLE.Client.Maui.csproj
@@ -36,10 +36,15 @@
 	  <WarningLevel>4</WarningLevel>
 	</PropertyGroup>
 	<PropertyGroup Condition="$(TargetFramework.Contains('-maccatalyst'))">
-	  <CreatePackage>false</CreatePackage>
-	  <CodesignKey>Mac Developer</CodesignKey>
-	  <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
+		<RuntimeIdentifier>maccatalyst-arm64</RuntimeIdentifier>
+		<CreatePackage>false</CreatePackage>
+		<CodesignKey>Mac Developer</CodesignKey>
+		<PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
 	</PropertyGroup>
+	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+		<RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />


### PR DESCRIPTION
I recently noticed that a couple of our sample clients are not yet inlcuded in the cake build script and therefore not built on Windows via GHA. Some of them I have already added on master, missing at this point is only BLE.Client.Maui, which is added by the PR. However, the Windows build currently fails (on the net8.0-windows target) with this error, which I don't quite understand:

```
Unable to optimize assemblies for performance: a valid runtime package was not found.
Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.
When targeting .NET 6 or higher, make sure to restore packages with the PublishReadyToRun property set to true.
```

I'm not even sure why anything is supposed to be 'published' here, because we actually just want to build the sample client, nothing more.

@AskBojesen Since you are our Windows expert: Do you understand this error and do you have an idea what's the best way to get rid of it?