### PR TITLE
Implement BleImplementation.TrySetStateAsync on Android

### DIFF
--- a/Source/Plugin.BLE/Android/BleImplementation.cs
+++ b/Source/Plugin.BLE/Android/BleImplementation.cs
@@ -85,8 +85,18 @@ namespace Plugin.BLE
 
         public override Task<bool> TrySetStateAsync(bool on)
         {
-            Abstractions.Trace.Message("WARNING TrySetStateAsync is not implemented for Android");
-            return Task<bool>.FromResult(false);
+            if (on)
+            {
+                var enable = new Intent(BluetoothAdapter.ActionRequestEnable);
+                enable.SetFlags(ActivityFlags.NewTask);
+                Application.Context.StartActivity(enable);
+                return Task.FromResult(true);
+            }
+            else
+            {
+                Abstractions.Trace.Message("WARNING TrySetStateAsync(false) is not implemented for Android");
+                return Task.FromResult(false);
+            }
         }
     }
 }

--- a/Source/Plugin.BLE/Android/BleImplementation.cs
+++ b/Source/Plugin.BLE/Android/BleImplementation.cs
@@ -85,18 +85,12 @@ namespace Plugin.BLE
 
         public override Task<bool> TrySetStateAsync(bool on)
         {
-            if (on)
-            {
-                var enable = new Intent(BluetoothAdapter.ActionRequestEnable);
-                enable.SetFlags(ActivityFlags.NewTask);
-                Application.Context.StartActivity(enable);
-                return Task.FromResult(true);
-            }
-            else
-            {
-                Abstractions.Trace.Message("WARNING TrySetStateAsync(false) is not implemented for Android");
-                return Task.FromResult(false);
-            }
+            const string ACTION_REQUEST_DISABLE = "android.bluetooth.adapter.action.REQUEST_DISABLE";
+
+            var intent = new Intent(on ? BluetoothAdapter.ActionRequestEnable : ACTION_REQUEST_DISABLE);
+            intent.SetFlags(ActivityFlags.NewTask);
+            Application.Context.StartActivity(intent);
+            return Task.FromResult(true);
         }
     }
 }

--- a/Source/Plugin.BLE/Shared/Contracts/IBluetoothLE.cs
+++ b/Source/Plugin.BLE/Shared/Contracts/IBluetoothLE.cs
@@ -31,8 +31,8 @@ namespace Plugin.BLE.Abstractions.Contracts
         bool IsOn { get; }
 
         /// <summary>
-        /// Try set the state of the Bluetooth on/off
-        /// 2024-01-14: Only supported in Windows
+        /// Try to set the state of the Bluetooth (on/off).
+        /// Supported on: Android & Windows.
         /// </summary>
         /// <param name="on"></param>
         /// <returns>true if the the method executed with success otherwice false</returns>


### PR DESCRIPTION
This implements the only method that works beyond API level 32. However, it only really covers the enable part, not the disabling. Fixes issue #821.
