### PR TITLE
Windows: Handle that a device is already connected

### DIFF
--- a/Source/BLE.Client/BLE.Client.WinConsole/WindowsDemos.cs
+++ b/Source/BLE.Client/BLE.Client.WinConsole/WindowsDemos.cs
@@ -87,9 +87,9 @@ namespace BLE.Client.WinConsole
             foreach (DeviceInformation di in collection)
             {
                 try
-                {
-                    Write($"Unpairing {di.Name}");
-                    _ = di.Pairing.UnpairAsync();
+                {                    
+                    DeviceUnpairingResult res = await di.Pairing.UnpairAsync();
+                    Write($"Unpairing {di.Name}: {res.Status}");
                 }
                 catch (Exception ex)
                 {

--- a/Source/Plugin.BLE/Plugin.BLE.csproj
+++ b/Source/Plugin.BLE/Plugin.BLE.csproj
@@ -3,7 +3,6 @@
 		<TargetFrameworks>netstandard2.0;net7.0-android33.0;net8.0-android34.0</TargetFrameworks>
 		<TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net7.0-ios;net7.0-maccatalyst;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;uap10.0.19041;net7.0-windows10.0.19041;net8.0-windows10.0.19041;net8.0-windows10.0.22000.0</TargetFrameworks>
-		<TargetFrameworks>net8.0-windows10.0.22000.0</TargetFrameworks>
 		<AssemblyName>Plugin.BLE</AssemblyName>
 		<RootNamespace>Plugin.BLE</RootNamespace>
 		<Version>3.1.0-beta.3</Version>

--- a/Source/Plugin.BLE/Plugin.BLE.csproj
+++ b/Source/Plugin.BLE/Plugin.BLE.csproj
@@ -3,6 +3,7 @@
 		<TargetFrameworks>netstandard2.0;net7.0-android33.0;net8.0-android34.0</TargetFrameworks>
 		<TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net7.0-ios;net7.0-maccatalyst;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;uap10.0.19041;net7.0-windows10.0.19041;net8.0-windows10.0.19041;net8.0-windows10.0.22000.0</TargetFrameworks>
+		<TargetFrameworks>net8.0-windows10.0.22000.0</TargetFrameworks>
 		<AssemblyName>Plugin.BLE</AssemblyName>
 		<RootNamespace>Plugin.BLE</RootNamespace>
 		<Version>3.1.0-beta.3</Version>

--- a/Source/Plugin.BLE/Shared/DeviceState.cs
+++ b/Source/Plugin.BLE/Shared/DeviceState.cs
@@ -21,7 +21,9 @@ namespace Plugin.BLE.Abstractions
         Connected,
 
         /// <summary>
-        /// OnAndroid: Device is connected to the system. In order to use this device please call connect it by using the Adapter. 
+        /// Android: Device is connected to the system. In order to use this device please call connect it by using the Adapter. 
+        /// Windows: Device is connected to the system, but the connect sequence has not been established in this Plugin.
+        /// iOS: Not used
         /// </summary>
         Limited
     }

--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -103,6 +103,10 @@ namespace Plugin.BLE.Windows
                 {
                     ConnectedDeviceRegistry[device.Id.ToString()] = device;
                     nativeDevice.ConnectionStatusChanged += Device_ConnectionStatusChanged;
+                    if (nativeDevice.ConnectionStatus == BluetoothConnectionStatus.Connected)
+                    {
+                        Device_ConnectionStatusChanged(nativeDevice, null);
+                    }
                 }
             }
             else

--- a/Source/Plugin.BLE/Windows/Device.cs
+++ b/Source/Plugin.BLE/Windows/Device.cs
@@ -97,6 +97,12 @@ namespace Plugin.BLE.Windows
             {
                 return DeviceState.Disconnected;
             }
+            if (gattSession is null)
+            {
+                // This is the case if the OS already is connected, but the ConnectInternal method has not yet been called
+                // Because the gattSession is created in the ConnectInternal method
+                return DeviceState.Limited;
+            }
             if (NativeDevice.ConnectionStatus == BluetoothConnectionStatus.Connected)
             {
                 return DeviceState.Connected;
@@ -158,7 +164,8 @@ namespace Plugin.BLE.Windows
             // ref https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothledevice.frombluetoothaddressasync
             // Creating a BluetoothLEDevice object by calling this method alone doesn't (necessarily) initiate a connection.
             // To initiate a connection, set GattSession.MaintainConnection to true, or call an uncached service discovery
-            // method on BluetoothLEDevice, or perform a read/write operation against the device.                        
+            // method on BluetoothLEDevice, or perform a read/write operation against the device.
+            // 2024-04-22: Note, that The DeviceInformation.Pairing.Custom.PairAsync also initiates a connection
             if (NativeDevice is null)
             {
                 Trace.Message("ConnectInternal says: Cannot connect since NativeDevice is null");


### PR DESCRIPTION
This change allows the connect sequence to be established even though the device is already connected.
An already connection could be due to pairing, which connects the device.

@janusw: This ended up with a simple solution :-)
If merging this new simple PR, we can discard the old one, which I have now closed... (https://github.com/dotnet-bluetooth-le/dotnet-bluetooth-le/pull/818)