### PR TITLE
fix Device.UpdateRssiAsync on Windows

### DIFF
--- a/Source/Plugin.BLE/Shared/Contracts/IDevice.cs
+++ b/Source/Plugin.BLE/Shared/Contracts/IDevice.cs
@@ -21,7 +21,7 @@ namespace Plugin.BLE.Abstractions.Contracts
         string Name { get; }
 
         /// <summary>
-        /// Last known rssi value in decibals.
+        /// Last known RSSI value in decibels.
         /// Can be updated via <see cref="UpdateRssiAsync()"/>.
         /// </summary>
         int Rssi { get; }
@@ -67,15 +67,15 @@ namespace Plugin.BLE.Abstractions.Contracts
         Task<IService> GetServiceAsync(Guid id, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Updates the rssi value.
+        /// Updates the RSSI value.
         /// </summary>
         /// <remarks>
-        /// Important:
-        /// On Android: This function will only work if the device is connected. The Rssi value will be determined once on the discovery of the device.
+        /// This method is only supported on Android, iOS and MacOS, but not on Windows.
+        /// On Android: This function will only work if the device is connected. The RSSI value will be determined once on the discovery of the device.
         /// </remarks>
         /// <returns>
-        /// A task that represents the asynchronous read operation. The Result property will contain a boolean that inticates if the update was successful.
-        /// The Task will finish after Rssi has been updated.
+        /// A task that represents the asynchronous read operation. The Result property will contain a boolean that indicates if the update was successful.
+        /// The Task will finish after the RSSI has been updated.
         /// </returns>
         Task<bool> UpdateRssiAsync();
 

--- a/Source/Plugin.BLE/Windows/Device.cs
+++ b/Source/Plugin.BLE/Windows/Device.cs
@@ -48,7 +48,7 @@ namespace Plugin.BLE.Windows
 
             Trace.Message("Request RSSI not supported in Windows");
 
-            return Task.FromResult(true);
+            return Task.FromResult(false);
         }
 
         public void DisposeNativeDevice()


### PR DESCRIPTION
* updating the RSSI is currently not supported on Windows, therefore the method should return a false value
* also: update the documentation and fix some typos
* this fixes #810