### PR TITLE
GHA: update to MacOS 14

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -75,7 +75,7 @@ jobs:
         path: ./Source/*/nuget/*Plugin.BLE*.nupkg
 
   macBuild:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
... in order to fix the build errors observed in #880, see https://github.com/dotnet-bluetooth-le/dotnet-bluetooth-le/pull/880#issuecomment-2280301790.