### PR TITLE
Added CustomPairing for Windows

### DIFF
--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -52,6 +52,7 @@ namespace Plugin.BLE.Windows
             DeviceInformationCustomPairing p = deviceInformation.Pairing.Custom;
             p.PairingRequested += PairingRequestedHandler;
             var result = await p.PairAsync(DevicePairingKinds.ConfirmOnly);
+            p.PairingRequested -= PairingRequestedHandler;
             Trace.Message($"BondAsync pairing result was {result.Status} with: {device.Name}: {device.Id}");
         }
 

--- a/Source/Plugin.BLE/Windows/Adapter.cs
+++ b/Source/Plugin.BLE/Windows/Adapter.cs
@@ -49,8 +49,24 @@ namespace Plugin.BLE.Windows
                 Trace.Message($"BondAsync cannot pair with: {device.Name}: {device.Id}");
                 return;
             }
-            DevicePairingResult result = await deviceInformation.Pairing.PairAsync();
+            DeviceInformationCustomPairing p = deviceInformation.Pairing.Custom;
+            p.PairingRequested += PairingRequestedHandler;
+            var result = await p.PairAsync(DevicePairingKinds.ConfirmOnly);
             Trace.Message($"BondAsync pairing result was {result.Status} with: {device.Name}: {device.Id}");
+        }
+
+        private static void PairingRequestedHandler(DeviceInformationCustomPairing sender, DevicePairingRequestedEventArgs args)
+        {
+            switch (args.PairingKind)
+            {
+                case DevicePairingKinds.ConfirmOnly:
+                    args.Accept();
+                    break;
+
+                default:
+                    Trace.Message("PairingKind " + args.PairingKind + " not supported");
+                    break;
+            }
         }
 
         protected override Task StartScanningForDevicesNativeAsync(ScanFilterOptions scanFilterOptions, bool allowDuplicatesKey, CancellationToken scanCancellationToken)


### PR DESCRIPTION
`PairAsync ` didn't work for Windows.
See [stack overflow](https://stackoverflow.com/questions/45191412/deviceinformation-pairasync-not-working-in-wpf)


* Added CustomPairing
* added default case to PairingHandler for error traceing