### PR TITLE
fixes #822, #883 Corrects ConnectedDevices and Device.State after Bluetooth.State is disabled.

### DIFF
--- a/Source/Plugin.BLE/Android/Adapter.cs
+++ b/Source/Plugin.BLE/Android/Adapter.cs
@@ -33,8 +33,21 @@ namespace Plugin.BLE.Android
             _bluetoothManager = bluetoothManager;
             _bluetoothAdapter = bluetoothManager.Adapter;
 
-            //bonding
-            var bondStatusBroadcastReceiver = new BondStatusBroadcastReceiver(this);
+			// Issue: #822, #883 Sync ConnectedDevices and Device.State with Bluetooth.State, for when the radio is disabled, all devices disconnect.
+			var bluetoothStateChanged = new BluetoothStatusBroadcastReceiver(state =>
+			{
+				if (state is BluetoothState.Off)
+				{
+					foreach (var connectedDevice in ConnectedDeviceRegistry)
+						HandleDisconnectedDevice(false, connectedDevice.Value, "Device Disconnects when Bluetooth is Disabled");
+
+					ConnectedDeviceRegistry.Clear();
+				}
+			});
+			_ = Application.Context.RegisterReceiver(bluetoothStateChanged, new IntentFilter(BluetoothAdapter.ActionStateChanged));
+
+			//bonding
+			var bondStatusBroadcastReceiver = new BondStatusBroadcastReceiver(this);
             Application.Context.RegisterReceiver(bondStatusBroadcastReceiver,
                 new IntentFilter(BluetoothDevice.ActionBondStateChanged));
 

--- a/Source/Plugin.BLE/Shared/AdapterBase.cs
+++ b/Source/Plugin.BLE/Shared/AdapterBase.cs
@@ -302,32 +302,31 @@ namespace Plugin.BLE.Abstractions
             DeviceConnected?.Invoke(this, new DeviceEventArgs { Device = device });
         }
 
-        /// <summary>
-        /// Handle disconnection of a device.
-        /// </summary>
-        public void HandleDisconnectedDevice(bool disconnectRequested, IDevice device)
-        {
-            if (disconnectRequested)
-            {
-                Trace.Message("DisconnectedPeripheral by user: {0}", device.Name);
-                DeviceDisconnected?.Invoke(this, new DeviceEventArgs { Device = device });
-            }
-            else
-            {
-                Trace.Message("DisconnectedPeripheral by lost signal: {0}", device.Name);
-                DeviceConnectionLost?.Invoke(this, new DeviceErrorEventArgs { Device = device });
+		/// <summary>
+		/// Handle disconnection of a device.
+		/// </summary>
+		public void HandleDisconnectedDevice(bool disconnectRequested, IDevice device, string message = "")
+		{
+			if (disconnectRequested)
+			{
+				Trace.Message("DisconnectedPeripheral by user: {0}", device.Name);
+				DeviceDisconnected?.Invoke(this, new DeviceEventArgs { Device = device });
+			}
+			else
+			{
+				string m = !string.IsNullOrWhiteSpace(message) ? message : "DisconnectedPeripheral by lost signal";
+				Trace.Message($"{m}: {device.Name}");
+				DeviceConnectionLost?.Invoke(this, new DeviceErrorEventArgs { Device = device, ErrorMessage = m });
 
-                if (DiscoveredDevicesRegistry.TryRemove(device.Id, out _))
-                {
-                    Trace.Message("Removed device from discovered devices list: {0}", device.Name);
-                }
-            }
-        }
+				if (DiscoveredDevicesRegistry.TryRemove(device.Id, out _))
+					Trace.Message("Removed device from discovered devices list: {0}", device.Name);
+			}
+		}
 
-        /// <summary>
-        /// Handle connection failure.
-        /// </summary>
-        public void HandleConnectionFail(IDevice device, string errorMessage)
+		/// <summary>
+		/// Handle connection failure.
+		/// </summary>
+		public void HandleConnectionFail(IDevice device, string errorMessage)
         {
             Trace.Message("Failed to connect peripheral {0}: {1}", device.Id, device.Name);
             DeviceConnectionError?.Invoke(this, new DeviceErrorEventArgs


### PR DESCRIPTION
Here's the simplest fix i could come up with.
For the record I find the proper fix refactors and deprecates all current Connection events consolidating into a single one, while Connection methods adopt a common signature Task<result> return type.