### PR TITLE
provide missing cancellation token to write characteristics method

### DIFF
--- a/Source/Plugin.BLE/Apple/Characteristic.cs
+++ b/Source/Plugin.BLE/Apple/Characteristic.cs
@@ -190,8 +190,8 @@ namespace Plugin.BLE.iOS
                             reject(exception);
                     }),
                     subscribeReject: handler => _bleCentralManagerDelegate.DisconnectedPeripheral += handler,
-                    unsubscribeReject: handler => _bleCentralManagerDelegate.DisconnectedPeripheral -= handler);
-
+                    unsubscribeReject: handler => _bleCentralManagerDelegate.DisconnectedPeripheral -= handler,
+                    token: cancellationToken);
                 }
                 else
                 {


### PR DESCRIPTION
The Characteristics.WriteNativeAsync method was not recognizing the cancellation token in mode WriteWithoutResponse on iOS (forget this in my last pull request).