### PR TITLE
Apple: Update default GetSystemConnectedOrPaired behaviour

### DIFF
--- a/Source/Plugin.BLE/Apple/Adapter.cs
+++ b/Source/Plugin.BLE/Apple/Adapter.cs
@@ -272,6 +272,10 @@ namespace Plugin.BLE.iOS
             {
                 serviceUuids = services.Select(guid => CBUUID.FromString(guid.ToString())).ToArray();
             }
+            else
+            {
+                serviceUuids = [];
+            }
 
             var nativeDevices = _centralManager.RetrieveConnectedPeripherals(serviceUuids);
 


### PR DESCRIPTION
Calls to `Plugin.Ble.Apple.Adapter.GetSystemConnectedOrPaired` with a null serviceUuids argument causes a `System.ArgumentNullException` in the `centralMananger.RetrieveConnectedPeripherals` call.

Update the Apple adapter method to pass an empty list when a null services list is provided, avoiding the null exception. This standardises the default behaviour across the supported platforms.

---

We noticed this inconsistency when testing our application; Apple devices would throw an exception, while the other platform wouldn't. While it's probably a reasonable expectation to wrap this in a try-catch, I think it makes more sense to just change the default behaviour to be consistent across the platforms; a null services argument only causes exceptions on Apple devices.

---

EDIT: Had some formatting issues on my local machine. Apologies for multiple force-pushes. This has been fixed now.