### PR TITLE
Fix iOS 32 bit UUIDs missing from advertisement records.

### DIFF
--- a/Source/BLE.Client/BLE.Client.Maui/ViewModels/BLEDeviceViewModel.cs
+++ b/Source/BLE.Client/BLE.Client.Maui/ViewModels/BLEDeviceViewModel.cs
@@ -76,7 +76,20 @@ namespace BLE.Client.Maui.ViewModels
             }
         }
 
-        public IReadOnlyList<AdvertisementRecord> AdvertisementRecords;
+        private IReadOnlyList<AdvertisementRecord> _adverts;
+        public IReadOnlyList<AdvertisementRecord> AdvertisementRecords
+        { 
+            get => _adverts;
+            set
+            {
+                if (_adverts != value)
+                {
+                    _adverts = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(Adverts));
+                }
+            }
+        }
         public string Adverts
         {
             get => String.Join('\n', AdvertisementRecords.Select(advert => $"{advert.Type}: 0x{Convert.ToHexString(advert.Data)}"));

--- a/Source/Plugin.BLE/Apple/Adapter.cs
+++ b/Source/Plugin.BLE/Apple/Adapter.cs
@@ -336,7 +336,7 @@ namespace Plugin.BLE.iOS
                                 // 128-bit UUID
                                 records.Add(new AdvertisementRecord(AdvertisementRecordType.UuidsComplete128Bit, cbuuid.Data.ToArray()));
                                 break;
-                            case 8:
+                            case 4:
                                 // 32-bit UUID
                                 records.Add(new AdvertisementRecord(AdvertisementRecordType.UuidCom32Bit, cbuuid.Data.ToArray()));
                                 break;
@@ -364,7 +364,7 @@ namespace Plugin.BLE.iOS
                                 // 128-bit solicited service UUID
                                 records.Add(new AdvertisementRecord(AdvertisementRecordType.SsUuids128Bit, cbuuid.Data.ToArray()));
                                 break;
-                            case 8:
+                            case 4:
                                 // 32-bit solicited service UUID
                                 records.Add(new AdvertisementRecord(AdvertisementRecordType.SsUuids32Bit, cbuuid.Data.ToArray()));
                                 break;


### PR DESCRIPTION
This pull request is in continuation of testing from #985. 
Fix iOS 32 bit UUIDs missing from advertisement record due to a typo with the length case. It was set to 8 bytes instead of 4 for 32 bit UUIDs.
Added backing property for sample to see all advertisement records when change/updated.

