### PR TITLE
Fix inconsistent AdvertisementRecordType names

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: nuget/setup-nuget@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,16 +13,16 @@ jobs:
   winBuild:
     runs-on: windows-2025
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - uses: nuget/setup-nuget@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
     - name: Set up JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '11'
@@ -34,7 +34,7 @@ jobs:
     - name: Build MVVMCross.Plugins.BLE NuGet
       run: dotnet build Source/MvvmCross.Plugins.BLE/MvvmCross.Plugins.BLE.csproj -c Release -t:restore,build,pack -p:PackageOutputPath=./nuget -p:Version=$(git describe) -p:ContinuousIntegrationBuild=true -p:DeterministicSourcePaths=false
     - name: Upload packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nupkg
         path: ./Source/*/nuget/*Plugin.BLE*.nupkg
@@ -51,11 +51,11 @@ jobs:
   macBuild:
     runs-on: macos-26
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
     - name: Setup XCode
@@ -76,11 +76,11 @@ jobs:
   linuxBuild:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
          dotnet-version: 10.0.x
     - name: Install workloads

--- a/.gitignore
+++ b/.gitignore
@@ -60,10 +60,12 @@ dlldata.c
 *.ilk
 *.meta
 *.obj
+*.orig
 *.pch
 *.pdb
 *.pgc
 *.pgd
+*.rej
 *.rsp
 *.sbr
 *.tlb

--- a/Source/Plugin.BLE/Android/Device.cs
+++ b/Source/Plugin.BLE/Android/Device.cs
@@ -301,14 +301,14 @@ namespace Plugin.BLE.Android
 
                     switch ((AdvertisementRecordType)type)
                     {
-                        case AdvertisementRecordType.ServiceDataUuid32Bit:
-                        case AdvertisementRecordType.SsUuids128Bit:
                         case AdvertisementRecordType.SsUuids16Bit:
                         case AdvertisementRecordType.SsUuids32Bit:
+                        case AdvertisementRecordType.SsUuids128Bit:
+                        case AdvertisementRecordType.UuidsComplete16Bit:
                         case AdvertisementRecordType.UuidsComplete32Bit:
                         case AdvertisementRecordType.UuidsComplete128Bit:
-                        case AdvertisementRecordType.UuidsComplete16Bit:
                         case AdvertisementRecordType.UuidsIncomplete16Bit:
+                        case AdvertisementRecordType.UuidsIncomplete32Bit:
                         case AdvertisementRecordType.UuidsIncomplete128Bit:
                             Array.Reverse(data);
                             break;

--- a/Source/Plugin.BLE/Android/Device.cs
+++ b/Source/Plugin.BLE/Android/Device.cs
@@ -305,10 +305,10 @@ namespace Plugin.BLE.Android
                         case AdvertisementRecordType.SsUuids128Bit:
                         case AdvertisementRecordType.SsUuids16Bit:
                         case AdvertisementRecordType.SsUuids32Bit:
-                        case AdvertisementRecordType.UuidCom32Bit:
+                        case AdvertisementRecordType.UuidsComplete32Bit:
                         case AdvertisementRecordType.UuidsComplete128Bit:
                         case AdvertisementRecordType.UuidsComplete16Bit:
-                        case AdvertisementRecordType.UuidsIncomple16Bit:
+                        case AdvertisementRecordType.UuidsIncomplete16Bit:
                         case AdvertisementRecordType.UuidsIncomplete128Bit:
                             Array.Reverse(data);
                             break;

--- a/Source/Plugin.BLE/Apple/Adapter.cs
+++ b/Source/Plugin.BLE/Apple/Adapter.cs
@@ -415,7 +415,24 @@ namespace Plugin.BLE.iOS
                         Buffer.BlockCopy(keyAsData, 0, arr, 0, keyAsData.Length);
                         Buffer.BlockCopy(valueAsData, 0, arr, keyAsData.Length, valueAsData.Length);
 
-                        records.Add(new AdvertisementRecord(AdvertisementRecordType.ServiceDataUuid16Bit, arr));
+                        AdvertisementRecordType recordType;
+                        switch (keyAsData.Length)
+                        {
+                            case 2:
+                                recordType = AdvertisementRecordType.ServiceDataUuid16Bit;
+                                break;
+                            case 4:
+                                recordType = AdvertisementRecordType.ServiceDataUuid32Bit;
+                                break;
+                            case 16:
+                                recordType = AdvertisementRecordType.ServiceDataUuid128Bit;
+                                break;
+                            default:
+                                Trace.Message("Parsing Advertisement: Unexpected service UUID length {0} bytes in service data. Skipping.", keyAsData.Length);
+                                continue;
+                        }
+
+                        records.Add(new AdvertisementRecord(recordType, arr));
                     }
                 }
                 else if (key == CBAdvertisement.IsConnectable)

--- a/Source/Plugin.BLE/Apple/Adapter.cs
+++ b/Source/Plugin.BLE/Apple/Adapter.cs
@@ -415,7 +415,7 @@ namespace Plugin.BLE.iOS
                         Buffer.BlockCopy(keyAsData, 0, arr, 0, keyAsData.Length);
                         Buffer.BlockCopy(valueAsData, 0, arr, keyAsData.Length, valueAsData.Length);
 
-                        records.Add(new AdvertisementRecord(AdvertisementRecordType.ServiceDataUuid16bit, arr));
+                        records.Add(new AdvertisementRecord(AdvertisementRecordType.ServiceDataUuid16Bit, arr));
                     }
                 }
                 else if (key == CBAdvertisement.IsConnectable)

--- a/Source/Plugin.BLE/Apple/Adapter.cs
+++ b/Source/Plugin.BLE/Apple/Adapter.cs
@@ -338,7 +338,7 @@ namespace Plugin.BLE.iOS
                                 break;
                             case 4:
                                 // 32-bit UUID
-                                records.Add(new AdvertisementRecord(AdvertisementRecordType.UuidCom32Bit, cbuuid.Data.ToArray()));
+                                records.Add(new AdvertisementRecord(AdvertisementRecordType.UuidsComplete32Bit, cbuuid.Data.ToArray()));
                                 break;
                             case 2:
                                 // 16-bit UUID
@@ -415,7 +415,7 @@ namespace Plugin.BLE.iOS
                         Buffer.BlockCopy(keyAsData, 0, arr, 0, keyAsData.Length);
                         Buffer.BlockCopy(valueAsData, 0, arr, keyAsData.Length, valueAsData.Length);
 
-                        records.Add(new AdvertisementRecord(AdvertisementRecordType.ServiceData, arr));
+                        records.Add(new AdvertisementRecord(AdvertisementRecordType.ServiceDataUuid16bit, arr));
                     }
                 }
                 else if (key == CBAdvertisement.IsConnectable)

--- a/Source/Plugin.BLE/Shared/AdvertisementRecord.cs
+++ b/Source/Plugin.BLE/Shared/AdvertisementRecord.cs
@@ -17,7 +17,7 @@ namespace Plugin.BLE.Abstractions
         ///«Incomplete List of 16-bit Service Class UUIDs»	Bluetooth Core 
         /// </summary>
         UuidsIncomplete16Bit = 0x02,
-        [ObsoleteAttribute("This member is obsolete. Use UuidsIncomplete16Bit instead.", false)]
+        [Obsolete($"This member is obsolete. Use {nameof(UuidsIncomplete16Bit)} instead.", false)]
         UuidsIncomple16Bit = 0x02,
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Plugin.BLE.Abstractions
         /// «Complete List of 32-bit Service Class UUIDs»	Bluetooth Core Specification:
         /// </summary>
         UuidsComplete32Bit = 0x05,
-        [ObsoleteAttribute("This member is obsolete. Use UuidsComplete32Bit instead.", false)]
+        [Obsolete($"This member is obsolete. Use {nameof(UuidsComplete32Bit)} instead.", false)]
         UuidCom32Bit = 0x05,
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Plugin.BLE.Abstractions
         /// 	​Core Specification Supplement, Part A, section 1.11
         /// </summary>
         ServiceDataUuid16Bit = 0x16,
-        [ObsoleteAttribute("This member is obsolete. Use ServiceDataUuid16Bit instead.", false)]
+        [Obsolete($"This member is obsolete. Use {nameof(ServiceDataUuid16Bit)} instead.", false)]
         ServiceData = 0x16,
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace Plugin.BLE.Abstractions
         /// ​«Service Data - 128-bit UUID»	​Core Specification Supplement, Part A, section 1.11
         /// </summary>
         ServiceDataUuid128Bit = 0x21,
-        [ObsoleteAttribute("This member is obsolete. Use ServiceDataUuid128Bit instead.", false)]
+        [Obsolete($"This member is obsolete. Use {nameof(ServiceDataUuid128Bit)} instead.", false)]
         ServiceData128Bit = 0x21,
 
         /// <summary>

--- a/Source/Plugin.BLE/Shared/AdvertisementRecord.cs
+++ b/Source/Plugin.BLE/Shared/AdvertisementRecord.cs
@@ -108,8 +108,8 @@ namespace Plugin.BLE.Abstractions
         /// «Service Data»	Bluetooth Core Specification:​«Service Data - 16-bit UUID»
         /// 	​Core Specification Supplement, Part A, section 1.11
         /// </summary>
-        ServiceDataUuid16bit = 0x16,
-        [ObsoleteAttribute("This member is obsolete. Use ServiceDataUuid16bit instead.", false)]
+        ServiceDataUuid16Bit = 0x16,
+        [ObsoleteAttribute("This member is obsolete. Use ServiceDataUuid16Bit instead.", false)]
         ServiceData = 0x16,
 
         /// <summary>

--- a/Source/Plugin.BLE/Shared/AdvertisementRecord.cs
+++ b/Source/Plugin.BLE/Shared/AdvertisementRecord.cs
@@ -1,4 +1,5 @@
-﻿using Plugin.BLE.Abstractions.Extensions;
+﻿using System;
+using Plugin.BLE.Abstractions.Extensions;
 
 namespace Plugin.BLE.Abstractions
 {
@@ -15,6 +16,8 @@ namespace Plugin.BLE.Abstractions
         /// <summary>
         ///«Incomplete List of 16-bit Service Class UUIDs»	Bluetooth Core 
         /// </summary>
+        UuidsIncomplete16Bit = 0x02,
+        [ObsoleteAttribute("This member is obsolete. Use UuidsIncomplete16Bit instead.", false)]
         UuidsIncomple16Bit = 0x02,
 
         /// <summary>
@@ -30,6 +33,8 @@ namespace Plugin.BLE.Abstractions
         /// <summary>
         /// «Complete List of 32-bit Service Class UUIDs»	Bluetooth Core Specification:
         /// </summary>
+        UuidsComplete32Bit = 0x05,
+        [ObsoleteAttribute("This member is obsolete. Use UuidsComplete32Bit instead.", false)]
         UuidCom32Bit = 0x05,
 
         /// <summary>
@@ -103,6 +108,8 @@ namespace Plugin.BLE.Abstractions
         /// «Service Data»	Bluetooth Core Specification:​«Service Data - 16-bit UUID»
         /// 	​Core Specification Supplement, Part A, section 1.11
         /// </summary>
+        ServiceDataUuid16bit = 0x16,
+        [ObsoleteAttribute("This member is obsolete. Use ServiceDataUuid16bit instead.", false)]
         ServiceData = 0x16,
 
         /// <summary>
@@ -153,6 +160,8 @@ namespace Plugin.BLE.Abstractions
         /// <summary>
         /// ​«Service Data - 128-bit UUID»	​Core Specification Supplement, Part A, section 1.11
         /// </summary>
+        ServiceDataUuid128Bit = 0x21,
+        [ObsoleteAttribute("This member is obsolete. Use ServiceDataUuid128Bit instead.", false)]
         ServiceData128Bit = 0x21,
 
         /// <summary>


### PR DESCRIPTION
Follow-up to the discussion from PR #989 ...

The `AdvertisementRecordType` enum has several members whose naming is inconsistent. This PR addresses the problem by adding properly named aliases and adding obsolescence warnings to the old names.

It also replaces the obsolete enum values by their new aliases in the library code and fixes some GHA warnings on the side.