### PR TITLE
Fix Android hanging on disconnection when status is Limited

### DIFF
--- a/Source/Plugin.BLE/Android/Device.cs
+++ b/Source/Plugin.BLE/Android/Device.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using Java.Util;
 using Plugin.BLE.Extensions;
 using Plugin.BLE.Abstractions.Extensions;
+using Plugin.BLE.Abstractions.Exceptions;
 
 namespace Plugin.BLE.Android
 {
@@ -212,7 +213,8 @@ namespace Plugin.BLE.Android
             else
             {
                 Trace.Message("[Warning]: Can't disconnect {0}. Gatt is null.", Name);
-            }
+				throw new DeviceConnectionException(Id, Name, $"Cannot disconnect device '{Name}': device is not properly connected (no GATT instance). Current state: {State}.");
+			}
         }
 
         /// <summary>

--- a/Source/Plugin.BLE/Android/Device.cs
+++ b/Source/Plugin.BLE/Android/Device.cs
@@ -107,11 +107,11 @@ namespace Plugin.BLE.Android
 
         private async Task<IReadOnlyList<IService>> DiscoverServicesInternal(CancellationToken cancellationToken)
         {
-	        if (_gatt == null)
-	        {
-		        Trace.Message("[Warning]: Can't discover services {0}. Gatt is null.", Name);
-	        }
-	        
+            if (_gatt == null)
+            {
+                Trace.Message("[Warning]: Can't discover services {0}. Gatt is null.", Name);
+            }
+            
             return await TaskBuilder
                 .FromEvent<IReadOnlyList<IService>, EventHandler<ServicesDiscoveredCallbackEventArgs>, EventHandler>(
                     execute: () =>
@@ -123,14 +123,14 @@ namespace Plugin.BLE.Android
                     },
                     getCompleteHandler: (complete, reject) => ((sender, args) =>
                     {
-	                    if (_gatt.Services == null)
-	                    {
-		                    complete(new List<IService>());
-	                    }
-	                    else
-	                    {
-		                    complete(_gatt.Services.Select(service => new Service(service, _gatt, _gattCallback, this)).ToList());
-	                    }
+                        if (_gatt.Services == null)
+                        {
+                            complete(new List<IService>());
+                        }
+                        else
+                        {
+                            complete(_gatt.Services.Select(service => new Service(service, _gatt, _gattCallback, this)).ToList());
+                        }
                     }),
                     subscribeComplete: handler => _gattCallback.ServicesDiscovered += handler,
                     unsubscribeComplete: handler => _gattCallback.ServicesDiscovered -= handler,
@@ -140,7 +140,7 @@ namespace Plugin.BLE.Android
                     }),
                     subscribeReject: handler => _gattCallback.ConnectionInterrupted += handler,
                     unsubscribeReject: handler => _gattCallback.ConnectionInterrupted -= handler,
-					token: cancellationToken);
+                    token: cancellationToken);
         }
 
         public void Connect(ConnectParameters connectParameters, CancellationToken cancellationToken)
@@ -212,9 +212,8 @@ namespace Plugin.BLE.Android
             }
             else
             {
-                Trace.Message("[Warning]: Can't disconnect {0}. Gatt is null.", Name);
-				throw new DeviceConnectionException(Id, Name, $"Cannot disconnect device '{Name}': device is not properly connected (no GATT instance). Current state: {State}.");
-			}
+                throw new DeviceConnectionException(Id, Name, $"Cannot disconnect device '{Name}': device is not properly connected (no GATT instance). Current state: {State}.");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request addresses issue: #986.

When the gatt instance is null, calling DisconnectDeviceAsync will hang forever. This seems to happen if a device with status "Limited" is passed in as the parameter since it is not fully connected (hence why gatt instance is null) the call should fail but currently does not. This pull request simply adds an exception that is thrown when the gatt instance is null. This fixes the thread hanging forever and also allows for the uses to debug and determine why the call failed.
