### PR TITLE
[3.2] Backport PR #994 to release 3.2

### DIFF
--- a/Source/Plugin.BLE/Android/Adapter.cs
+++ b/Source/Plugin.BLE/Android/Adapter.cs
@@ -308,8 +308,6 @@ namespace Plugin.BLE.Android
             var nativeDevice = _bluetoothAdapter.GetRemoteDevice(macBytes);
             if (nativeDevice == null)
                 throw new Abstractions.Exceptions.DeviceConnectionException(deviceGuid,"", $"[Adapter] Device {deviceGuid} not found.");
-            if (!nativeDevice.SupportsBLE())
-                throw new Abstractions.Exceptions.DeviceConnectionException(deviceGuid,"", $"[Adapter] Device {deviceGuid} does not support BLE.");
             var device = new Device(this, nativeDevice, null);
 
             await ConnectToDeviceAsync(device, connectParameters, cancellationToken);

--- a/Source/Plugin.BLE/Android/Device.cs
+++ b/Source/Plugin.BLE/Android/Device.cs
@@ -16,6 +16,7 @@ using System.Threading;
 using Java.Util;
 using Plugin.BLE.Extensions;
 using Plugin.BLE.Abstractions.Extensions;
+using Plugin.BLE.Abstractions.Exceptions;
 
 namespace Plugin.BLE.Android
 {

--- a/Source/Plugin.BLE/Android/Device.cs
+++ b/Source/Plugin.BLE/Android/Device.cs
@@ -9,6 +9,7 @@ using Android.Content;
 using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Abstractions.Utils;
+using Plugin.BLE.Android.Extensions;
 using Plugin.BLE.Android.CallbackEventArgs;
 using Trace = Plugin.BLE.Abstractions.Trace;
 using System.Threading;
@@ -147,6 +148,9 @@ namespace Plugin.BLE.Android
         {
             IsOperationRequested = true;
             ConnectParameters = connectParameters;
+
+            if (connectParameters.CheckIsLeDeviceType && !NativeDevice.SupportsBLE())
+                throw new DeviceConnectionException(Id, Name, $"[Device] Device {Id} does not support BLE, type is {NativeDevice.Type}. You can disable this check, see more info in ConnectParameters.CheckIsLeDeviceType description.");
 
             if (connectParameters.ForceBleTransport)
             {

--- a/Source/Plugin.BLE/Shared/ConnectParameter.cs
+++ b/Source/Plugin.BLE/Shared/ConnectParameter.cs
@@ -3,24 +3,33 @@
     /// <summary>
     /// Connection parameters. Contains platform specific parameters needed to achieved connection
     /// </summary>
-    public struct ConnectParameters
+    public readonly struct ConnectParameters
     {
         /// <summary>
         /// Android only, from documentation:  
         /// boolean: Whether to directly connect to the remote device (false) or to automatically connect as soon as the remote device becomes available (true).
         /// </summary>
-        public bool AutoConnect { get; }
+        public bool AutoConnect { get; init; } = false;
 
         /// <summary>
         /// Android only: For Dual Mode device, force transport mode to LE. The default is false.
         /// </summary>
-        public bool ForceBleTransport { get; }
+        public bool ForceBleTransport { get; init; } = false;
+
+        /// <summary>
+        /// Android only: Strict BluetoothDeviceType checking.
+        /// The connection will only be attempted if the device supports LE, otherwise a DeviceConnectionException will be thrown.
+        /// This check is an early “warning” of what might happen next - error GATT 133 or Bluetooth stack fault.
+        /// The BluetoothDeviceType may be Unknown immediately after the device is rebooted, or if the type is not accepted correctly, try scanning to get or update the type.
+        /// If the device intentionally does not declare the connection type, you can disable this check.
+        /// </summary>
+        public bool CheckIsLeDeviceType { get; init; } = false;
 
         /// <summary>
         /// Windows only, mapped to:
         /// https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothlepreferredconnectionparameters
         /// </summary>
-        public ConnectionParameterSet ConnectionParameterSet { get; }
+        public ConnectionParameterSet ConnectionParameterSet { get; init; } = ConnectionParameterSet.None;
 
         /// <summary>
         /// Default-constructed connection parameters (all parameters set to false).
@@ -33,14 +42,17 @@
         /// <param name="autoConnect">Android only: Whether to directly connect to the remote device (false) or to automatically connect as soon as the remote device becomes available (true). The default is false.</param>
         /// <param name="forceBleTransport">Android only: For Dual Mode device, force transport mode to LE. The default is false.</param>
         /// <param name="connectionParameterSet">Windows only: Default is None, where this has no effect - use eg. ThroughputOptimized for firmware upload to a device</param>
+        /// <param name="checkIsLeDeviceType">Android only: Check if device supports LE. The default is false.</param>
         public ConnectParameters(
             bool autoConnect = false,
             bool forceBleTransport = false,
-            ConnectionParameterSet connectionParameterSet = ConnectionParameterSet.None)
+            ConnectionParameterSet connectionParameterSet = ConnectionParameterSet.None,
+            bool checkIsLeDeviceType = false)
         {
             AutoConnect = autoConnect;
             ForceBleTransport = forceBleTransport;
             ConnectionParameterSet = connectionParameterSet;
+            CheckIsLeDeviceType = checkIsLeDeviceType;
         }
     }
 }

--- a/Source/Plugin.BLE/Shared/ConnectParameter.cs
+++ b/Source/Plugin.BLE/Shared/ConnectParameter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Plugin.BLE.Abstractions
 {
     /// <summary>
-    /// Connection parameters. Contains platform specific parameters needed to achieved connection
+    /// Connection parameters. Contains platform specific parameters needed to achieve connection
     /// </summary>
     public readonly struct ConnectParameters
     {

--- a/Source/Plugin.BLE/Shared/ConnectParameter.cs
+++ b/Source/Plugin.BLE/Shared/ConnectParameter.cs
@@ -9,12 +9,12 @@
         /// Android only, from documentation:  
         /// boolean: Whether to directly connect to the remote device (false) or to automatically connect as soon as the remote device becomes available (true).
         /// </summary>
-        public bool AutoConnect { get; init; } = false;
+        public bool AutoConnect { get; } = false;
 
         /// <summary>
         /// Android only: For Dual Mode device, force transport mode to LE. The default is false.
         /// </summary>
-        public bool ForceBleTransport { get; init; } = false;
+        public bool ForceBleTransport { get; } = false;
 
         /// <summary>
         /// Android only: Strict BluetoothDeviceType checking.
@@ -23,13 +23,13 @@
         /// The BluetoothDeviceType may be Unknown immediately after the device is rebooted, or if the type is not accepted correctly, try scanning to get or update the type.
         /// If the device intentionally does not declare the connection type, you can disable this check.
         /// </summary>
-        public bool CheckIsLeDeviceType { get; init; } = false;
+        public bool CheckIsLeDeviceType { get; } = false;
 
         /// <summary>
         /// Windows only, mapped to:
         /// https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothlepreferredconnectionparameters
         /// </summary>
-        public ConnectionParameterSet ConnectionParameterSet { get; init; } = ConnectionParameterSet.None;
+        public ConnectionParameterSet ConnectionParameterSet { get; } = ConnectionParameterSet.None;
 
         /// <summary>
         /// Default-constructed connection parameters (all parameters set to false).


### PR DESCRIPTION
This is the backport of @alex3696's PR #994 to the 3.2 release branch. It fixes issue #877, which is a regression in v3.1 upwards. The backport makes the fix available for Xamarin (which is not supported any more in v3.3), as requested by @KevinJosephMorin.

It adds a new option `ConnectParameters.CheckIsLeDeviceType`, which default to `false` and guards the `SupportsBLE()` check from #855, which was previously active by default and caused the problems described in #877.

Here I had to remove the init setters from the `ConnectParameters` struct again (which were added in #994) since they caused problems when building for Xamarin apparently (see e.g. https://stackoverflow.com/questions/64749385/predefined-type-system-runtime-compilerservices-isexternalinit-is-not-defined).