### PR TITLE
Readme: update links and move usage information to separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,8 +358,9 @@ The BLE API implementation (especially on **Android**) has the following limitat
 
 ## Useful Links
 
-- [Bluetooth Core Specification v4.2 (2014)](https://www.bluetooth.com/specifications/specs/core-specification-4-2/)
-- [Bluetooth Core Specification v5.4 (2023)](https://www.bluetooth.com/specifications/specs/core-specification-5-4/)
+- [Bluetooth Core Specification v5.4 (2024)](https://www.bluetooth.com/specifications/specs/core-specification-amended-5-4/)
+- [Bluetooth Core Specification v6.2 (2025)](https://www.bluetooth.com/specifications/specs/core-specification-6-2/)
+- [Bluetooth Assigned Numbers](https://www.bluetooth.com/specifications/assigned-numbers/)
 - [Android Bluetooth LE guideline](https://developer.android.com/develop/connectivity/bluetooth/ble/ble-overview)
 - [iOS CoreBluetooth Best Practices](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/BestPracticesForInteractingWithARemotePeripheralDevice/BestPracticesForInteractingWithARemotePeripheralDevice.html)
 - [iOS CoreBluetooth Background Modes](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW7)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Build status: [![Build status](https://github.com/dotnet-bluetooth-le/dotnet-blu
 
 **Important Note:** With the term *"vanilla"* we mean the non-MvvmCross version, i.e. the pure Xamarin or MAUI plugin. You **can** use it without MvvmCross, if you download the vanilla package.
 
+
 ## Support & Limitations
 
 [Release Notes](doc/changelog.md)
@@ -18,6 +19,7 @@ Build status: [![Build status](https://github.com/dotnet-bluetooth-le/dotnet-blu
 | Xamarin.UWP     | 1709 - 10.0.16299 | >= 2.2.0    |
 | MAUI (Android, iOS, Mac, WinUI) |   | >= 3.0.0    |
 
+
 ## Nuget Packages
 
 | package              | stable    | beta      | downloads |
@@ -25,89 +27,11 @@ Build status: [![Build status](https://github.com/dotnet-bluetooth-le/dotnet-blu
 | Plugin.BLE           | [![NuGet](https://img.shields.io/nuget/v/Plugin.BLE.svg?style=flat)](https://www.nuget.org/packages/Plugin.BLE) | [![NuGet Beta](https://img.shields.io/nuget/vpre/Plugin.BLE.svg?style=flat)](https://www.nuget.org/packages/Plugin.BLE) | [![Downloads](https://img.shields.io/nuget/dt/Plugin.BLE.svg)](https://www.nuget.org/packages/Plugin.BLE)
 | MvvmCross.Plugin.BLE | [![NuGet MvvMCross](https://img.shields.io/nuget/v/MvvmCross.Plugin.BLE.svg?style=flat)](https://www.nuget.org/packages/MvvmCross.Plugin.BLE) | [![NuGet MvvMCross Beta](https://img.shields.io/nuget/vpre/MvvmCross.Plugin.BLE.svg?style=flat)](https://www.nuget.org/packages/MvvmCross.Plugin.BLE) | [![Downloads](https://img.shields.io/nuget/dt/MvvmCross.Plugin.BLE.svg)](https://www.nuget.org/packages/MvvmCross.Plugin.BLE)
 
-## Installation
 
-**Vanilla**
+## Usage
 
-```
-// stable
-Install-Package Plugin.BLE
-// or pre-release
-Install-Package Plugin.BLE -Pre
-```
+- [Usage](doc/usage.md)
 
-**MvvmCross**
-
-```
-Install-Package MvvmCross.Plugin.BLE
-// or
-Install-Package MvvmCross.Plugin.BLE -Pre
-```
-
-## Permissions
-
-### Android
-
-Add these permissions to AndroidManifest.xml. For Marshmallow and above, please follow [Requesting Runtime Permissions in Android Marshmallow](https://devblogs.microsoft.com/xamarin/requesting-runtime-permissions-in-android-marshmallow/) and don't forget to prompt the user for the location permission.
-
-```xml
-<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-<uses-permission android:name="android.permission.BLUETOOTH" />
-<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-```
-
-Android 12 and above may require one or more of the following additional runtime permissions, depending on which features of the library you are using (see [the android Bluetooth permissions documentation](https://developer.android.com/guide/topics/connectivity/bluetooth/permissions))
-```xml
-<uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
-<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-<uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
-```
-
-Add this line to your manifest if you want to declare that your app is available to BLE-capable devices **only**:
-```xml
-<uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
-````
-
-### iOS
-
-On iOS you must add the following keys to your `Info.plist`
-
-```xml
-<key>UIBackgroundModes</key>
-<array>
-    <!--for connecting to devices (client)-->
-    <string>bluetooth-central</string>
-    <!--for server configurations if needed-->
-    <string>bluetooth-peripheral</string>
-</array>
-
-<!--Description of the Bluetooth request message (required on iOS 10, deprecated)-->
-<key>NSBluetoothPeripheralUsageDescription</key>
-<string>YOUR CUSTOM MESSAGE</string>
-
-<!--Description of the Bluetooth request message (required on iOS 13)-->
-<key>NSBluetoothAlwaysUsageDescription</key>
-<string>YOUR CUSTOM MESSAGE</string>
-````
-
-### MacOS
-
-On MacOS (version 11 and above) you must add the following keys to your `Info.plist`:
-
-```xml
-<!--Description of the Bluetooth request message-->
-<key>NSBluetoothAlwaysUsageDescription</key>
-<string>YOUR CUSTOM MESSAGE</string>
-````
-
-### UWP
-
-Add this line to the Package Manifest (.appxmanifest):
-
-```xml
-<DeviceCapability Name="bluetooth" />
-```
 
 ## Sample app
 
@@ -123,216 +47,6 @@ We provide a sample Xamarin.Forms app, that is a basic bluetooth LE scanner. Wit
 
 Have a look at the code and use it as starting point to learn about the plugin and play around with it.
 
-## Usage  
-
-**Vanilla**
-
-```csharp
-var ble = CrossBluetoothLE.Current;
-var adapter = CrossBluetoothLE.Current.Adapter;
-```
-
-**MvvmCross**
-
-The MvvmCross plugin registers `IBluetoothLE` and  `IAdapter` as lazy initialized singletons. You can resolve/inject them as any other MvvmCross service. You don't have to resolve/inject both. It depends on your use case.
-
-```csharp
-var ble = Mvx.Resolve<IBluetoothLE>();
-var adapter = Mvx.Resolve<IAdapter>();
-```
-or
-```csharp
-MyViewModel(IBluetoothLE ble, IAdapter adapter)
-{
-    this.ble = ble;
-    this.adapter = adapter;
-}
-```
-
-Please make sure you have this code in your LinkerPleaseLink.cs file
-
-```csharp
-public void Include(MvvmCross.Plugins.BLE.Plugin plugin)
-{
-    plugin.Load();
-}
-```
-
-### IBluetoothLE
-#### Get the bluetooth status
-```csharp
-var state = ble.State;
-```
-You can also listen for State changes. So you can react if the user turns on/off bluetooth on your smartphone.
-```csharp
-ble.StateChanged += (s, e) =>
-{
-    Debug.WriteLine($"The bluetooth state changed to {e.NewState}");
-};
-```
-
-
-### IAdapter
-#### Scan for devices
-```csharp
-adapter.DeviceDiscovered += (s,a) => deviceList.Add(a.Device);
-await adapter.StartScanningForDevicesAsync();
-```
-
-#### Scan Filtering
-```csharp
-var scanFilterOptions = new ScanFilterOptions();
-scanFilterOptions.ServiceUuids = new [] {guid1, guid2, etc}; // cross platform filter
-scanFilterOptions.ManufacturerDataFilters = new [] { new ManufacturerDataFilter(1), new ManufacturerDataFilter(2) }; // android only filter
-scanFilterOptions.DeviceAddresses = new [] {"80:6F:B0:43:8D:3B","80:6F:B0:25:C3:15",etc}; // android only filter
-await adapter.StartScanningForDevicesAsync(scanFilterOptions);
-```
-
-##### ScanTimeout
-Set `adapter.ScanTimeout` to specify the maximum duration of the scan.
-
-##### ScanMode
-Set `adapter.ScanMode` to specify scan mode. It must be set **before** calling `StartScanningForDevicesAsync()`. Changing it while scanning, will not affect the current scan.
-
-#### Connect to device
-`ConnectToDeviceAsync` returns a Task that finishes if the device has been connected successful. Otherwise a `DeviceConnectionException` gets thrown.
-
-```csharp
-try
-{
-    await _adapter.ConnectToDeviceAsync(device);
-}
-catch(DeviceConnectionException e)
-{
-    // ... could not connect to device
-}
-```
-
-#### Connect to known Device
-`ConnectToKnownDeviceAsync` can connect to a device with a given GUID. This means that if the device GUID is known, no scan is necessary to connect to a device. This can be very useful for a fast background reconnect.
-Always use a cancellation token with this method.
-- On **iOS** it will attempt to connect indefinitely, even if out of range, so the only way to cancel it is with the token.
-- On **Android** this will throw a GATT ERROR in a couple of seconds if the device is out of range.
-
-```csharp
-try
-{
-    await _adapter.ConnectToKnownDeviceAsync(guid, cancellationToken);
-}
-catch(DeviceConnectionException e)
-{
-    // ... could not connect to device
-}
-```
-
-#### Get services
-```csharp
-var services = await connectedDevice.GetServicesAsync();
-```
-or get a specific service:
-```csharp
-var service = await connectedDevice.GetServiceAsync(Guid.Parse("ffe0ecd2-3d16-4f8d-90de-e89e7fc396a5"));
-```
-
-#### Get characteristics
-```csharp
-var characteristics = await service.GetCharacteristicsAsync();
-```
-or get a specific characteristic:
-```csharp
-var characteristic = await service.GetCharacteristicAsync(Guid.Parse("d8de624e-140f-4a22-8594-e2216b84a5f2"));
-```
-
-#### Read characteristic
-```csharp
-var bytes = await characteristic.ReadAsync();
-```
-
-#### Write characteristic
-```csharp
-await characteristic.WriteAsync(bytes);
-```
-
-#### Characteristic notifications
-```csharp
-characteristic.ValueUpdated += (o, args) =>
-{
-    var bytes = args.Characteristic.Value;
-};
-
-await characteristic.StartUpdatesAsync();
-
-```
-
-#### Get descriptors
-```csharp
-var descriptors = await characteristic.GetDescriptorsAsync();
-```
-
-#### Read descriptor
-```csharp
-var bytes = await descriptor.ReadAsync();
-```
-
-#### Write descriptor
-```csharp
-await descriptor.WriteAsync(bytes);
-```
-
-#### Get System Devices
-
-Returns all BLE devices connected or bonded (only Android) to the system. In order to use the device in the app you have to first call ConnectAsync.
-- For iOS the implementation uses get [retrieveConnectedPeripherals(services)](https://developer.apple.com/reference/corebluetooth/cbcentralmanager/1518924-retrieveconnectedperipherals)
-- For Android this function merges the functionality of the following API calls:
-    - [getConnectedDevices](https://developer.android.com/reference/android/bluetooth/BluetoothManager.html#getConnectedDevices(int))
-    - [getBondedDevices()](https://developer.android.com/reference/android/bluetooth/BluetoothAdapter.html#getBondedDevices())
-
-
-```csharp
-
-var systemDevices = adapter.GetSystemConnectedOrPairedDevices();
-
-foreach(var device in systemDevices)
-{
-    await _adapter.ConnectToDeviceAsync(device);
-}
-
-```
-## Caution! Important remarks / API limitations
-
-The BLE API implementation (especially on **Android**) has the following limitations:
-
-- *Characteristic/Descriptor Write*: make sure you call characteristic.**WriteAsync**(...) from the **main thread**, failing to do so will most probably result in a GattWriteError.
-- *Sequential calls*: **Always** wait for the previous BLE command to finish before invoking the next. The Android API needs its calls to be serial, otherwise calls that do not wait for the previous ones will fail with some type of GattError. A more explicit example: if you call this in your view lifecycle (onAppearing etc) all these methods return **void** and 100% don't guarantee that any await bleCommand() called here will be truly awaited by other lifecycle methods.
-- *Scan with services filter*: On **specifically Android 4.3** the *scan services filter does not work* (due to the underlying android implementation). For android 4.3 you will have to use a workaround and scan without a filter and then manually filter by using the advertisement data (which contains the published service GUIDs).
-
-## Best practice
-
-### API
-- Surround Async API calls in try-catch blocks. Most BLE calls can/will throw an exception in certain cases, this is especially true for Android. We will try to update the xml doc to reflect this.
-```csharp
-    try
-    {
-        await _adapter.ConnectToDeviceAsync(device);
-    }
-    catch(DeviceConnectionException ex)
-    {
-        //specific
-    }
-    catch(Exception ex)
-    {
-        //generic
-    }
-```
-
-- **Avoid caching of Characteristic or Service instances between connection sessions**. This includes saving a reference to them in your class between connection sessions etc. After a device has been disconnected all Service & Characteristic instances become **invalid**. Always **use GetServiceAsync and GetCharacteristicAsync to get a valid instance**.
-
-### General BLE iOS, Android
-
-- Scanning: Avoid performing BLE device operations like Connect, Read, Write etc while scanning for devices. Scanning is battery-intensive.
-    - Try to stop scanning before performing device operations (connect/read/write/etc).
-    - Try to stop scanning as soon as you find the desired device.
-    - Never scan on a loop, and set a time limit on your scan.
 
 ## How to build the nuget package
 
@@ -347,15 +61,6 @@ The BLE API implementation (especially on **Android**) has the following limitat
     `nuget pack ../Source/MvvmCross.Plugins.BLE/MvvmCross.Plugins.BLE.csproj`
 
 
-
-## Extended topics
-
-- [How to set custom trace method?](doc/howto_custom_trace.md)
-- [Characteristic Properties](doc/characteristics.md)
-- [Scan Mode Mapping](doc/scanmode_mapping.md)
-- [iOS state restoration (basic support)](doc/ios_state_restoration.md)
-
-
 ## Useful Links
 
 - [Bluetooth Core Specification v5.4 (2024)](https://www.bluetooth.com/specifications/specs/core-specification-amended-5-4/)
@@ -366,9 +71,11 @@ The BLE API implementation (especially on **Android**) has the following limitat
 - [iOS CoreBluetooth Background Modes](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW7)
 - [Monkey Robotics](https://github.com/xamarin/Monkey.BluetoothLE)
 
+
 ## How to contribute
 
 We usually do our development work on a branch with the name of the milestone. So please base your pull requests on the currently open development branch.
+
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ Build status: [![Build status](https://github.com/dotnet-bluetooth-le/dotnet-blu
 ## Usage
 
 - [Usage](doc/usage.md)
-
+  - [Installation](doc/usage.md#installation)
+  - [Permissions](doc/usage.md#permissions)
+  - [API Usage](doc/usage.md#api-usage)
+  - [Important remarks / API limitations](doc/usage.md#important-remarks--api-limitations)
+  - [Best practice](doc/usage.md#best-practice)
+  - [Extended topics](doc/usage.md#extended-topics)
 
 ## Sample app
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -130,7 +130,7 @@
 - UWP support pre-release
 
 
-## 2.1 MacOS  
+## 2.1 macOS  
 
 ### 2.1.3
 - Feature: additional scan filtering on Android, for manufacturer data, service data, device adress or device name (fixes #515)
@@ -152,7 +152,7 @@
 ### 2.1.1 Service Release for 2.1.0
 - [iOS] #373, #377 Fixed trace output that caused NRE.
 
-### 2.1.0 Stable Release MacOS
+### 2.1.0 Stable Release macOS
 - Use IReadOnlyLists for Services/Characteristics/Descriptors and concurrent collections for DiscoveredDevices/ConnectedDevices
 Should prevent crashes like: #320
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -5,7 +5,7 @@
   - [Permissions](#permissions)
     - [Android](#android)
     - [iOS](#ios)
-    - [MacOS](#macos)
+    - [macOS](#macos)
     - [UWP](#uwp)
   - [API Usage](#api-usage)
     - [IBluetoothLE](#ibluetoothle)
@@ -97,9 +97,9 @@ On iOS you must add the following keys to your `Info.plist`
 <string>YOUR CUSTOM MESSAGE</string>
 ```
 
-### MacOS
+### macOS
 
-On MacOS (version 11 and above) you must add the following keys to your `Info.plist`:
+On macOS (version 11 and above) you must add the following keys to your `Info.plist`:
 
 ```xml
 <!--Description of the Bluetooth request message-->

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -73,7 +73,7 @@ Android 12 and above may require one or more of the following additional runtime
 Add this line to your manifest if you want to declare that your app is available to BLE-capable devices **only**:
 ```xml
 <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
-````
+```
 
 ### iOS
 
@@ -95,7 +95,7 @@ On iOS you must add the following keys to your `Info.plist`
 <!--Description of the Bluetooth request message (required on iOS 13)-->
 <key>NSBluetoothAlwaysUsageDescription</key>
 <string>YOUR CUSTOM MESSAGE</string>
-````
+```
 
 ### MacOS
 
@@ -105,7 +105,7 @@ On MacOS (version 11 and above) you must add the following keys to your `Info.pl
 <!--Description of the Bluetooth request message-->
 <key>NSBluetoothAlwaysUsageDescription</key>
 <string>YOUR CUSTOM MESSAGE</string>
-````
+```
 
 ### UWP
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -329,7 +329,7 @@ The BLE API implementation (especially on **Android**) has the following limitat
 
 ## Extended topics
 
-- [How to set custom trace method?](doc/howto_custom_trace.md)
-- [Characteristic Properties](doc/characteristics.md)
-- [Scan Mode Mapping](doc/scanmode_mapping.md)
-- [iOS state restoration (basic support)](doc/ios_state_restoration.md)
+- [How to set custom trace method?](howto_custom_trace.md)
+- [Characteristic Properties](characteristics.md)
+- [Scan Mode Mapping](scanmode_mapping.md)
+- [iOS state restoration (basic support)](ios_state_restoration.md)

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -1,5 +1,36 @@
 # Usage
 
+- [Usage](#usage)
+  - [Installation](#installation)
+  - [Permissions](#permissions)
+    - [Android](#android)
+    - [iOS](#ios)
+    - [MacOS](#macos)
+    - [UWP](#uwp)
+  - [API Usage](#api-usage)
+    - [IBluetoothLE](#ibluetoothle)
+      - [Get the bluetooth status](#get-the-bluetooth-status)
+    - [IAdapter](#iadapter)
+      - [Scan for devices](#scan-for-devices)
+      - [Scan Filtering](#scan-filtering)
+      - [Connect to device](#connect-to-device)
+      - [Connect to known Device](#connect-to-known-device)
+      - [Get services](#get-services)
+      - [Get characteristics](#get-characteristics)
+      - [Read characteristic](#read-characteristic)
+      - [Write characteristic](#write-characteristic)
+      - [Characteristic notifications](#characteristic-notifications)
+      - [Get descriptors](#get-descriptors)
+      - [Read descriptor](#read-descriptor)
+      - [Write descriptor](#write-descriptor)
+      - [Get System Devices](#get-system-devices)
+  - [Important remarks / API limitations](#important-remarks--api-limitations)
+  - [Best practice](#best-practice)
+    - [API](#api)
+    - [General BLE iOS, Android](#general-ble-ios-android)
+  - [Extended topics](#extended-topics)
+
+
 ## Installation
 
 **Vanilla**

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -1,0 +1,304 @@
+# Usage
+
+## Installation
+
+**Vanilla**
+
+```
+// stable
+Install-Package Plugin.BLE
+// or pre-release
+Install-Package Plugin.BLE -Pre
+```
+
+**MvvmCross**
+
+```
+Install-Package MvvmCross.Plugin.BLE
+// or
+Install-Package MvvmCross.Plugin.BLE -Pre
+```
+
+## Permissions
+
+### Android
+
+Add these permissions to AndroidManifest.xml. For Marshmallow and above, please follow [Requesting Runtime Permissions in Android Marshmallow](https://devblogs.microsoft.com/xamarin/requesting-runtime-permissions-in-android-marshmallow/) and don't forget to prompt the user for the location permission.
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.BLUETOOTH" />
+<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+```
+
+Android 12 and above may require one or more of the following additional runtime permissions, depending on which features of the library you are using (see [the android Bluetooth permissions documentation](https://developer.android.com/guide/topics/connectivity/bluetooth/permissions))
+```xml
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+<uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+```
+
+Add this line to your manifest if you want to declare that your app is available to BLE-capable devices **only**:
+```xml
+<uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
+````
+
+### iOS
+
+On iOS you must add the following keys to your `Info.plist`
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <!--for connecting to devices (client)-->
+    <string>bluetooth-central</string>
+    <!--for server configurations if needed-->
+    <string>bluetooth-peripheral</string>
+</array>
+
+<!--Description of the Bluetooth request message (required on iOS 10, deprecated)-->
+<key>NSBluetoothPeripheralUsageDescription</key>
+<string>YOUR CUSTOM MESSAGE</string>
+
+<!--Description of the Bluetooth request message (required on iOS 13)-->
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>YOUR CUSTOM MESSAGE</string>
+````
+
+### MacOS
+
+On MacOS (version 11 and above) you must add the following keys to your `Info.plist`:
+
+```xml
+<!--Description of the Bluetooth request message-->
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>YOUR CUSTOM MESSAGE</string>
+````
+
+### UWP
+
+Add this line to the Package Manifest (.appxmanifest):
+
+```xml
+<DeviceCapability Name="bluetooth" />
+```
+
+## API Usage
+
+**Vanilla**
+
+```csharp
+var ble = CrossBluetoothLE.Current;
+var adapter = CrossBluetoothLE.Current.Adapter;
+```
+
+**MvvmCross**
+
+The MvvmCross plugin registers `IBluetoothLE` and  `IAdapter` as lazy initialized singletons. You can resolve/inject them as any other MvvmCross service. You don't have to resolve/inject both. It depends on your use case.
+
+```csharp
+var ble = Mvx.Resolve<IBluetoothLE>();
+var adapter = Mvx.Resolve<IAdapter>();
+```
+or
+```csharp
+MyViewModel(IBluetoothLE ble, IAdapter adapter)
+{
+    this.ble = ble;
+    this.adapter = adapter;
+}
+```
+
+Please make sure you have this code in your LinkerPleaseLink.cs file
+
+```csharp
+public void Include(MvvmCross.Plugins.BLE.Plugin plugin)
+{
+    plugin.Load();
+}
+```
+
+### IBluetoothLE
+#### Get the bluetooth status
+```csharp
+var state = ble.State;
+```
+You can also listen for State changes. So you can react if the user turns on/off bluetooth on your smartphone.
+```csharp
+ble.StateChanged += (s, e) =>
+{
+    Debug.WriteLine($"The bluetooth state changed to {e.NewState}");
+};
+```
+
+
+### IAdapter
+#### Scan for devices
+```csharp
+adapter.DeviceDiscovered += (s,a) => deviceList.Add(a.Device);
+await adapter.StartScanningForDevicesAsync();
+```
+
+#### Scan Filtering
+```csharp
+var scanFilterOptions = new ScanFilterOptions();
+scanFilterOptions.ServiceUuids = new [] {guid1, guid2, etc}; // cross platform filter
+scanFilterOptions.ManufacturerDataFilters = new [] { new ManufacturerDataFilter(1), new ManufacturerDataFilter(2) }; // android only filter
+scanFilterOptions.DeviceAddresses = new [] {"80:6F:B0:43:8D:3B","80:6F:B0:25:C3:15",etc}; // android only filter
+await adapter.StartScanningForDevicesAsync(scanFilterOptions);
+```
+
+##### ScanTimeout
+Set `adapter.ScanTimeout` to specify the maximum duration of the scan.
+
+##### ScanMode
+Set `adapter.ScanMode` to specify scan mode. It must be set **before** calling `StartScanningForDevicesAsync()`. Changing it while scanning, will not affect the current scan.
+
+#### Connect to device
+`ConnectToDeviceAsync` returns a Task that finishes if the device has been connected successful. Otherwise a `DeviceConnectionException` gets thrown.
+
+```csharp
+try
+{
+    await _adapter.ConnectToDeviceAsync(device);
+}
+catch(DeviceConnectionException e)
+{
+    // ... could not connect to device
+}
+```
+
+#### Connect to known Device
+`ConnectToKnownDeviceAsync` can connect to a device with a given GUID. This means that if the device GUID is known, no scan is necessary to connect to a device. This can be very useful for a fast background reconnect.
+Always use a cancellation token with this method.
+- On **iOS** it will attempt to connect indefinitely, even if out of range, so the only way to cancel it is with the token.
+- On **Android** this will throw a GATT ERROR in a couple of seconds if the device is out of range.
+
+```csharp
+try
+{
+    await _adapter.ConnectToKnownDeviceAsync(guid, cancellationToken);
+}
+catch(DeviceConnectionException e)
+{
+    // ... could not connect to device
+}
+```
+
+#### Get services
+```csharp
+var services = await connectedDevice.GetServicesAsync();
+```
+or get a specific service:
+```csharp
+var service = await connectedDevice.GetServiceAsync(Guid.Parse("ffe0ecd2-3d16-4f8d-90de-e89e7fc396a5"));
+```
+
+#### Get characteristics
+```csharp
+var characteristics = await service.GetCharacteristicsAsync();
+```
+or get a specific characteristic:
+```csharp
+var characteristic = await service.GetCharacteristicAsync(Guid.Parse("d8de624e-140f-4a22-8594-e2216b84a5f2"));
+```
+
+#### Read characteristic
+```csharp
+var bytes = await characteristic.ReadAsync();
+```
+
+#### Write characteristic
+```csharp
+await characteristic.WriteAsync(bytes);
+```
+
+#### Characteristic notifications
+```csharp
+characteristic.ValueUpdated += (o, args) =>
+{
+    var bytes = args.Characteristic.Value;
+};
+
+await characteristic.StartUpdatesAsync();
+
+```
+
+#### Get descriptors
+```csharp
+var descriptors = await characteristic.GetDescriptorsAsync();
+```
+
+#### Read descriptor
+```csharp
+var bytes = await descriptor.ReadAsync();
+```
+
+#### Write descriptor
+```csharp
+await descriptor.WriteAsync(bytes);
+```
+
+#### Get System Devices
+
+Returns all BLE devices connected or bonded (only Android) to the system. In order to use the device in the app you have to first call ConnectAsync.
+- For iOS the implementation uses get [retrieveConnectedPeripherals(services)](https://developer.apple.com/reference/corebluetooth/cbcentralmanager/1518924-retrieveconnectedperipherals)
+- For Android this function merges the functionality of the following API calls:
+    - [getConnectedDevices](https://developer.android.com/reference/android/bluetooth/BluetoothManager.html#getConnectedDevices(int))
+    - [getBondedDevices()](https://developer.android.com/reference/android/bluetooth/BluetoothAdapter.html#getBondedDevices())
+
+
+```csharp
+
+var systemDevices = adapter.GetSystemConnectedOrPairedDevices();
+
+foreach(var device in systemDevices)
+{
+    await _adapter.ConnectToDeviceAsync(device);
+}
+
+```
+
+## Important remarks / API limitations
+
+The BLE API implementation (especially on **Android**) has the following limitations:
+
+- *Characteristic/Descriptor Write*: make sure you call characteristic.**WriteAsync**(...) from the **main thread**, failing to do so will most probably result in a GattWriteError.
+- *Sequential calls*: **Always** wait for the previous BLE command to finish before invoking the next. The Android API needs its calls to be serial, otherwise calls that do not wait for the previous ones will fail with some type of GattError. A more explicit example: if you call this in your view lifecycle (onAppearing etc) all these methods return **void** and 100% don't guarantee that any await bleCommand() called here will be truly awaited by other lifecycle methods.
+- *Scan with services filter*: On **specifically Android 4.3** the *scan services filter does not work* (due to the underlying android implementation). For android 4.3 you will have to use a workaround and scan without a filter and then manually filter by using the advertisement data (which contains the published service GUIDs).
+
+## Best practice
+
+### API
+- Surround Async API calls in try-catch blocks. Most BLE calls can/will throw an exception in certain cases, this is especially true for Android. We will try to update the xml doc to reflect this.
+```csharp
+    try
+    {
+        await _adapter.ConnectToDeviceAsync(device);
+    }
+    catch(DeviceConnectionException ex)
+    {
+        //specific
+    }
+    catch(Exception ex)
+    {
+        //generic
+    }
+```
+
+- **Avoid caching of Characteristic or Service instances between connection sessions**. This includes saving a reference to them in your class between connection sessions etc. After a device has been disconnected all Service & Characteristic instances become **invalid**. Always **use GetServiceAsync and GetCharacteristicAsync to get a valid instance**.
+
+### General BLE iOS, Android
+
+- Scanning: Avoid performing BLE device operations like Connect, Read, Write etc while scanning for devices. Scanning is battery-intensive.
+    - Try to stop scanning before performing device operations (connect/read/write/etc).
+    - Try to stop scanning as soon as you find the desired device.
+    - Never scan on a loop, and set a time limit on your scan.
+
+## Extended topics
+
+- [How to set custom trace method?](doc/howto_custom_trace.md)
+- [Characteristic Properties](doc/characteristics.md)
+- [Scan Mode Mapping](doc/scanmode_mapping.md)
+- [iOS state restoration (basic support)](doc/ios_state_restoration.md)


### PR DESCRIPTION
The README file is currently huge and confusing. It contains a lot of information and it's not easy to find something specific. I try to make it more clear and structured, by moving all information related to the usage of the library and API into a separate file. The new usage file has a TOC on top, and its primary sections are directly linked from the README.

This way the README is a bit easier to grasp. It contains only general information and all usage-related information is separated and linked to.

Also the links to the BT specs are updated and a link to the Assigned-Numbers document is added.