### PR TITLE
[3.1] Backport PR #994 to release 3.1

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,16 +13,16 @@ jobs:
   winBuild:
     runs-on: windows-2022
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: nuget/setup-nuget@v2
+    - uses: nuget/setup-nuget@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Set up JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '11'
@@ -33,34 +33,34 @@ jobs:
         & dotnet workload install maui --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json
         & dotnet workload install android ios maccatalyst tvos macos maui wasm-tools maui-maccatalyst --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
     - name: Clean
-      uses: cake-build/cake-action@v2
+      uses: cake-build/cake-action@v3
       with:
         script-path: .build/build.cake
         target: Clean
     - name: Restore
-      uses: cake-build/cake-action@v2
+      uses: cake-build/cake-action@v3
       with:
         script-path: .build/build.cake
         target: Restore
     - name: Build Libs
-      uses: cake-build/cake-action@v2
+      uses: cake-build/cake-action@v3
       with:
         script-path: .build/build.cake
         target: BuildLibs
     - name: Build Clients
-      uses: cake-build/cake-action@v2
+      uses: cake-build/cake-action@v3
       with:
         script-path: .build/build.cake
         target: BuildClients
     - name: Builds Tests
-      uses: cake-build/cake-action@v2
+      uses: cake-build/cake-action@v3
       with:
         script-path: .build/build.cake
         target: BuildTests
     - name: Run Tests
-      uses: cake-build/cake-action@v2
+      uses: cake-build/cake-action@v3
       with:
         script-path: .build/build.cake
         target: RunTests
@@ -69,7 +69,7 @@ jobs:
     - name: Build MVVMCross.Plugins.BLE NuGet
       run: msbuild .\Source\MvvmCross.Plugins.BLE\MvvmCross.Plugins.BLE.csproj /p:Configuration=Release /t:restore,build,pack /p:PackageOutputPath=./nuget /p:Version=$(git describe) /p:ContinuousIntegrationBuild=true /p:DeterministicSourcePaths=false
     - name: Upload packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nupkg
         path: ./Source/*/nuget/*Plugin.BLE*.nupkg
@@ -77,11 +77,11 @@ jobs:
   macBuild:
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Setup XCode
@@ -107,11 +107,11 @@ jobs:
   linuxBuild:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
          dotnet-version: 8.0.x
     - name: Install workloads

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   winBuild:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
       with:
@@ -75,7 +75,7 @@ jobs:
         path: ./Source/*/nuget/*Plugin.BLE*.nupkg
 
   macBuild:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
       with:
@@ -87,12 +87,16 @@ jobs:
     - name: Setup XCode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15'
+        xcode-version: '16'
     - name: Install .NET MAUI
       run: |
         dotnet nuget locals all --clear
         dotnet workload install maui --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json
         dotnet workload install android ios maccatalyst tvos macos maui wasm-tools maui-maccatalyst --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json
+    - name: Install Android tools
+      run: |
+        ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager \
+        --sdk_root=$ANDROID_SDK_ROOT "platform-tools" "platforms;android-33" "build-tools;33.0.0"
     - name: Build Plugin.BLE NuGet
       run: dotnet build ./Source/Plugin.BLE/Plugin.BLE.csproj /p:Configuration=Release /t:restore,build,pack /p:Version=$(git describe) /p:ContinuousIntegrationBuild=true /p:DeterministicSourcePaths=false
     - name: Build MVVMCross.Plugins.BLE NuGet
@@ -115,7 +119,7 @@ jobs:
     - name: Install Android tools
       run: |
         ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager \
-        --sdk_root=$ANDROID_SDK_ROOT "platform-tools"
+        --sdk_root=$ANDROID_SDK_ROOT "platform-tools" "platforms;android-33" "build-tools;33.0.0"
     - name: Build Plugin.BLE NuGet
       run: dotnet build ./Source/Plugin.BLE/Plugin.BLE.csproj -p:Configuration=Release -t:restore,build,pack -p:Version=$(git describe) -p:ContinuousIntegrationBuild=true -p:DeterministicSourcePaths=false
     - name: Build MVVMCross.Plugins.BLE NuGet

--- a/Source/Plugin.BLE/Android/Adapter.cs
+++ b/Source/Plugin.BLE/Android/Adapter.cs
@@ -307,8 +307,6 @@ namespace Plugin.BLE.Android
             var nativeDevice = _bluetoothAdapter.GetRemoteDevice(macBytes);
             if (nativeDevice == null)
                 throw new Abstractions.Exceptions.DeviceConnectionException(deviceGuid,"", $"[Adapter] Device {deviceGuid} not found.");
-            if (!nativeDevice.SupportsBLE())
-                throw new Abstractions.Exceptions.DeviceConnectionException(deviceGuid,"", $"[Adapter] Device {deviceGuid} does not support BLE.");
             var device = new Device(this, nativeDevice, null);
 
             await ConnectToDeviceAsync(device, connectParameters, cancellationToken);

--- a/Source/Plugin.BLE/Android/Device.cs
+++ b/Source/Plugin.BLE/Android/Device.cs
@@ -16,6 +16,7 @@ using System.Threading;
 using Java.Util;
 using Plugin.BLE.Extensions;
 using Plugin.BLE.Abstractions.Extensions;
+using Plugin.BLE.Abstractions.Exceptions;
 
 namespace Plugin.BLE.Android
 {

--- a/Source/Plugin.BLE/Android/Device.cs
+++ b/Source/Plugin.BLE/Android/Device.cs
@@ -146,11 +146,12 @@ namespace Plugin.BLE.Android
 
         public void Connect(ConnectParameters connectParameters, CancellationToken cancellationToken)
         {
-            IsOperationRequested = true;
             ConnectParameters = connectParameters;
 
             if (connectParameters.CheckIsLeDeviceType && !NativeDevice.SupportsBLE())
                 throw new DeviceConnectionException(Id, Name, $"[Device] Device {Id} does not support BLE, type is {NativeDevice.Type}. You can disable this check, see more info in ConnectParameters.CheckIsLeDeviceType description.");
+
+            IsOperationRequested = true;
 
             if (connectParameters.ForceBleTransport)
             {

--- a/Source/Plugin.BLE/Android/Device.cs
+++ b/Source/Plugin.BLE/Android/Device.cs
@@ -9,6 +9,7 @@ using Android.Content;
 using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Abstractions.Utils;
+using Plugin.BLE.Android.Extensions;
 using Plugin.BLE.Android.CallbackEventArgs;
 using Trace = Plugin.BLE.Abstractions.Trace;
 using System.Threading;
@@ -146,6 +147,9 @@ namespace Plugin.BLE.Android
         {
             IsOperationRequested = true;
             ConnectParameters = connectParameters;
+
+            if (connectParameters.CheckIsLeDeviceType && !NativeDevice.SupportsBLE())
+                throw new DeviceConnectionException(Id, Name, $"[Device] Device {Id} does not support BLE, type is {NativeDevice.Type}. You can disable this check, see more info in ConnectParameters.CheckIsLeDeviceType description.");
 
             if (connectParameters.ForceBleTransport)
             {

--- a/Source/Plugin.BLE/Shared/ConnectParameter.cs
+++ b/Source/Plugin.BLE/Shared/ConnectParameter.cs
@@ -3,24 +3,33 @@
     /// <summary>
     /// Connection parameters. Contains platform specific parameters needed to achieved connection
     /// </summary>
-    public struct ConnectParameters
+    public readonly struct ConnectParameters
     {
         /// <summary>
         /// Android only, from documentation:  
         /// boolean: Whether to directly connect to the remote device (false) or to automatically connect as soon as the remote device becomes available (true).
         /// </summary>
-        public bool AutoConnect { get; }
+        public bool AutoConnect { get; init; } = false;
 
         /// <summary>
         /// Android only: For Dual Mode device, force transport mode to LE. The default is false.
         /// </summary>
-        public bool ForceBleTransport { get; }
+        public bool ForceBleTransport { get; init; } = false;
+
+        /// <summary>
+        /// Android only: Strict BluetoothDeviceType checking.
+        /// The connection will only be attempted if the device supports LE, otherwise a DeviceConnectionException will be thrown.
+        /// This check is an early “warning” of what might happen next - error GATT 133 or Bluetooth stack fault.
+        /// The BluetoothDeviceType may be Unknown immediately after the device is rebooted, or if the type is not accepted correctly, try scanning to get or update the type.
+        /// If the device intentionally does not declare the connection type, you can disable this check.
+        /// </summary>
+        public bool CheckIsLeDeviceType { get; init; } = false;
 
         /// <summary>
         /// Windows only, mapped to:
         /// https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothlepreferredconnectionparameters
         /// </summary>
-        public ConnectionParameterSet ConnectionParameterSet { get; }
+        public ConnectionParameterSet ConnectionParameterSet { get; init; } = ConnectionParameterSet.None;
 
         /// <summary>
         /// Default-constructed connection parameters (all parameters set to false).
@@ -33,14 +42,17 @@
         /// <param name="autoConnect">Android only: Whether to directly connect to the remote device (false) or to automatically connect as soon as the remote device becomes available (true). The default is false.</param>
         /// <param name="forceBleTransport">Android only: For Dual Mode device, force transport mode to LE. The default is false.</param>
         /// <param name="connectionParameterSet">Windows only: Default is None, where this has no effect - use eg. ThroughputOptimized for firmware upload to a device</param>
+        /// <param name="checkIsLeDeviceType">Android only: Check if device supports LE. The default is false.</param>
         public ConnectParameters(
             bool autoConnect = false,
             bool forceBleTransport = false,
-            ConnectionParameterSet connectionParameterSet = ConnectionParameterSet.None)
+            ConnectionParameterSet connectionParameterSet = ConnectionParameterSet.None,
+            bool checkIsLeDeviceType = false)
         {
             AutoConnect = autoConnect;
             ForceBleTransport = forceBleTransport;
             ConnectionParameterSet = connectionParameterSet;
+            CheckIsLeDeviceType = checkIsLeDeviceType;
         }
     }
 }

--- a/Source/Plugin.BLE/Shared/ConnectParameter.cs
+++ b/Source/Plugin.BLE/Shared/ConnectParameter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Plugin.BLE.Abstractions
 {
     /// <summary>
-    /// Connection parameters. Contains platform specific parameters needed to achieved connection
+    /// Connection parameters. Contains platform specific parameters needed to achieve connection
     /// </summary>
     public readonly struct ConnectParameters
     {

--- a/Source/Plugin.BLE/Shared/ConnectParameter.cs
+++ b/Source/Plugin.BLE/Shared/ConnectParameter.cs
@@ -9,12 +9,12 @@
         /// Android only, from documentation:  
         /// boolean: Whether to directly connect to the remote device (false) or to automatically connect as soon as the remote device becomes available (true).
         /// </summary>
-        public bool AutoConnect { get; init; } = false;
+        public bool AutoConnect { get; } = false;
 
         /// <summary>
         /// Android only: For Dual Mode device, force transport mode to LE. The default is false.
         /// </summary>
-        public bool ForceBleTransport { get; init; } = false;
+        public bool ForceBleTransport { get; } = false;
 
         /// <summary>
         /// Android only: Strict BluetoothDeviceType checking.
@@ -23,13 +23,13 @@
         /// The BluetoothDeviceType may be Unknown immediately after the device is rebooted, or if the type is not accepted correctly, try scanning to get or update the type.
         /// If the device intentionally does not declare the connection type, you can disable this check.
         /// </summary>
-        public bool CheckIsLeDeviceType { get; init; } = false;
+        public bool CheckIsLeDeviceType { get; } = false;
 
         /// <summary>
         /// Windows only, mapped to:
         /// https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothlepreferredconnectionparameters
         /// </summary>
-        public ConnectionParameterSet ConnectionParameterSet { get; init; } = ConnectionParameterSet.None;
+        public ConnectionParameterSet ConnectionParameterSet { get; } = ConnectionParameterSet.None;
 
         /// <summary>
         /// Default-constructed connection parameters (all parameters set to false).

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+ {
+   "sdk": {
+     "version": "8.0.401",
+     "rollForward": "latestPatch"
+   }
+ }


### PR DESCRIPTION
Since issue #877 is a regression introduced in version 3.1.0, and that still seems to be our most widely-used release at present (according to the nuget.org stats), I decided to backport the fix from #994 not only to release 3.2, but also to 3.1. I was worried a bit that it might be a problem to still get the CI running on that old release, but after some fiddling with the GHA setup it seems I got it to work ...