### PR TITLE
Support api level 33 overrides for memory save characteristic values

### DIFF
--- a/Source/Plugin.BLE/Android/CallbackEventArgs/CharacteristicReadCallbackEventArgs.cs
+++ b/Source/Plugin.BLE/Android/CallbackEventArgs/CharacteristicReadCallbackEventArgs.cs
@@ -7,10 +7,13 @@ namespace Plugin.BLE.Android.CallbackEventArgs
         public BluetoothGattCharacteristic Characteristic { get; }
         public GattStatus Status { get; }
 
-        public CharacteristicReadCallbackEventArgs(BluetoothGattCharacteristic characteristic, GattStatus status)
+        public byte[] Value { get; }
+
+        public CharacteristicReadCallbackEventArgs(BluetoothGattCharacteristic characteristic, GattStatus status, byte[] value)
         {
             Characteristic = characteristic;
             Status = status;
+            Value = value;
         }
     }
 }

--- a/Source/Plugin.BLE/Android/Characteristic.cs
+++ b/Source/Plugin.BLE/Android/Characteristic.cs
@@ -189,7 +189,7 @@ namespace Plugin.BLE.Android
         {
             if (e.Characteristic.Uuid == NativeCharacteristic.Uuid)
             {
-                ValueUpdated?.Invoke(this, new CharacteristicUpdatedEventArgs(this));
+                ValueUpdated?.Invoke(this, new CharacteristicUpdatedEventArgs(this, e.Value));
             }
         }
     }

--- a/Source/Plugin.BLE/Android/Characteristic.cs
+++ b/Source/Plugin.BLE/Android/Characteristic.cs
@@ -52,7 +52,7 @@ namespace Plugin.BLE.Android
                     if (args.Characteristic.Uuid == NativeCharacteristic.Uuid)
                     {
                         int resultCode = (int)args.Status;
-                        complete((args.Characteristic.GetValue(), resultCode));
+                        complete((args.Value, resultCode));
                     }
                 }),
                 subscribeComplete: handler => _gattCallback.CharacteristicValueRead += handler,

--- a/Source/Plugin.BLE/Android/GattCallback.cs
+++ b/Source/Plugin.BLE/Android/GattCallback.cs
@@ -177,10 +177,14 @@ namespace Plugin.BLE.Android
             CharacteristicValueRead?.Invoke(this, new CharacteristicReadCallbackEventArgs(characteristic, status, characteristic.GetValue()));
         }
 
-        // public override Void OnCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, Byte[] value, GattStatus status)
-        // {
-        //     return base.OnCharacteristicRead(gatt, characteristic, value, status);
-        // }
+        public override void OnCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, byte[] value, GattStatus status)
+        {
+            base.OnCharacteristicRead(gatt, characteristic, value, status);
+
+            Trace.Message("OnCharacteristicRead with value: value {0}; status {1}", value.ToHexString(), status);
+
+            CharacteristicValueRead?.Invoke(this, new CharacteristicReadCallbackEventArgs(characteristic, status, value));
+        }
 
         public override void OnCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic)
         {
@@ -189,6 +193,15 @@ namespace Plugin.BLE.Android
             Trace.Message("OnCharacteristicChanged: value {0}", characteristic.GetValue().ToHexString());
 
             CharacteristicValueUpdated?.Invoke(this, new CharacteristicReadCallbackEventArgs(characteristic, GattStatus.Success, characteristic.GetValue()));
+        }
+
+        public override void OnCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, byte[] value)
+        {
+            base.OnCharacteristicChanged(gatt, characteristic, value);
+
+            Trace.Message("OnCharacteristicChanged with value: value {0}", value.ToHexString());
+
+            CharacteristicValueUpdated?.Invoke(this, new CharacteristicReadCallbackEventArgs(characteristic, GattStatus.Success, value));
         }
 
         public override void OnCharacteristicWrite(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, GattStatus status)

--- a/Source/Plugin.BLE/Android/GattCallback.cs
+++ b/Source/Plugin.BLE/Android/GattCallback.cs
@@ -174,8 +174,13 @@ namespace Plugin.BLE.Android
 
             Trace.Message("OnCharacteristicRead: value {0}; status {1}", characteristic.GetValue().ToHexString(), status);
 
-            CharacteristicValueRead?.Invoke(this, new CharacteristicReadCallbackEventArgs(characteristic, status));
+            CharacteristicValueRead?.Invoke(this, new CharacteristicReadCallbackEventArgs(characteristic, status, characteristic.GetValue()));
         }
+
+        // public override Void OnCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, Byte[] value, GattStatus status)
+        // {
+        //     return base.OnCharacteristicRead(gatt, characteristic, value, status);
+        // }
 
         public override void OnCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic)
         {
@@ -183,7 +188,7 @@ namespace Plugin.BLE.Android
 
             Trace.Message("OnCharacteristicChanged: value {0}", characteristic.GetValue().ToHexString());
 
-            CharacteristicValueUpdated?.Invoke(this, new CharacteristicReadCallbackEventArgs(characteristic, GattStatus.Success));
+            CharacteristicValueUpdated?.Invoke(this, new CharacteristicReadCallbackEventArgs(characteristic, GattStatus.Success, characteristic.GetValue()));
         }
 
         public override void OnCharacteristicWrite(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, GattStatus status)

--- a/Source/Plugin.BLE/Apple/Characteristic.cs
+++ b/Source/Plugin.BLE/Apple/Characteristic.cs
@@ -301,7 +301,7 @@ namespace Plugin.BLE.iOS
         {
             if (e.Characteristic.UUID == NativeCharacteristic.UUID)
             {
-                ValueUpdated?.Invoke(this, new CharacteristicUpdatedEventArgs(this, e.Characteristic.Value));
+                ValueUpdated?.Invoke(this, new CharacteristicUpdatedEventArgs(this, e.Characteristic.Value?.ToArray()));
             }
         }
     }

--- a/Source/Plugin.BLE/Apple/Characteristic.cs
+++ b/Source/Plugin.BLE/Apple/Characteristic.cs
@@ -301,7 +301,7 @@ namespace Plugin.BLE.iOS
         {
             if (e.Characteristic.UUID == NativeCharacteristic.UUID)
             {
-                ValueUpdated?.Invoke(this, new CharacteristicUpdatedEventArgs(this));
+                ValueUpdated?.Invoke(this, new CharacteristicUpdatedEventArgs(this, e.Characteristic.Value));
             }
         }
     }

--- a/Source/Plugin.BLE/Shared/EventArgs/CharacteristicUpdatedEventArgs.cs
+++ b/Source/Plugin.BLE/Shared/EventArgs/CharacteristicUpdatedEventArgs.cs
@@ -12,12 +12,15 @@ namespace Plugin.BLE.Abstractions.EventArgs
         /// </summary>
         public ICharacteristic Characteristic { get; set; }
 
+        public byte[] Value { get; }
+
         /// <summary>
         /// Constructor.
         /// </summary>
-        public CharacteristicUpdatedEventArgs(ICharacteristic characteristic)
+        public CharacteristicUpdatedEventArgs(ICharacteristic characteristic, byte[] value)
         {
             Characteristic = characteristic;
+            Value = value;
         }
     }
 }

--- a/Source/Plugin.BLE/Windows/Characteristic.cs
+++ b/Source/Plugin.BLE/Windows/Characteristic.cs
@@ -98,7 +98,7 @@ namespace Plugin.BLE.Windows
         private void OnCharacteristicValueChanged(object sender, GattValueChangedEventArgs e)
         {
             _value = e.CharacteristicValue?.ToArray(); //add value to array
-            ValueUpdated?.Invoke(this, new CharacteristicUpdatedEventArgs(this));
+            ValueUpdated?.Invoke(this, new CharacteristicUpdatedEventArgs(this, _value));
         }
     }
 }


### PR DESCRIPTION
On Android API level 33+, there are two overrides that provide the updated characteristic value. Using these values ensures the data remains memory-safe, as reading directly from the characteristic itself may result in the value changing too quickly.